### PR TITLE
Add OneSignal notification edge function

### DIFF
--- a/src/lib/notification.ts
+++ b/src/lib/notification.ts
@@ -1,0 +1,17 @@
+import { supabase } from "./supabaseClient";
+
+export interface PushNotificationPayload {
+  message: string;
+  playerId?: string;
+  segment?: string;
+}
+
+export async function sendPushNotification(payload: PushNotificationPayload) {
+  const { data, error } = await supabase.functions.invoke(
+    "send_push_notification",
+    { body: payload },
+  );
+
+  if (error) throw new Error(error.message);
+  return data;
+}

--- a/supabase/functions/send_push_notification/deno.json
+++ b/supabase/functions/send_push_notification/deno.json
@@ -1,0 +1,5 @@
+{
+  "tasks": {
+    "start": "deno run --allow-net --allow-env --watch index.ts"
+  }
+}

--- a/supabase/functions/send_push_notification/index.ts
+++ b/supabase/functions/send_push_notification/index.ts
@@ -1,0 +1,64 @@
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers":
+    "authorization, x-client-info, apikey, content-type",
+};
+
+serve(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response("ok", { headers: corsHeaders });
+  }
+
+  try {
+    const { message, playerId, segment } = await req.json();
+
+    if (!message) {
+      throw new Error("Message is required");
+    }
+
+    const restApiKey = Deno.env.get("ONESIGNAL_REST_API_KEY");
+    if (!restApiKey) {
+      throw new Error("Missing OneSignal REST API key");
+    }
+
+    const payload: Record<string, unknown> = {
+      app_id: "b6d82074-2797-435a-9586-63bc0b55a696",
+      contents: { en: message },
+    };
+
+    if (playerId) {
+      payload.include_player_ids = [playerId];
+    } else if (segment) {
+      payload.included_segments = [segment];
+    } else {
+      throw new Error("playerId or segment is required");
+    }
+
+    const response = await fetch("https://onesignal.com/api/v1/notifications", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Basic ${restApiKey}`,
+      },
+      body: JSON.stringify(payload),
+    });
+
+    const data = await response.json();
+
+    if (!response.ok) {
+      throw new Error(data.errors?.[0] || "Failed to send notification");
+    }
+
+    return new Response(JSON.stringify(data), {
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+      status: 200,
+    });
+  } catch (error) {
+    return new Response(JSON.stringify({ error: error.message }), {
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+      status: 400,
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- add Supabase `send_push_notification` function that POSTs to OneSignal
- add helper `sendPushNotification` to invoke the new edge function
- fix function invocation name

## Testing
- `npm run lint` *(fails: couldn't find an eslint.config)*
- `npm run build-no-errors` *(fails: vite not found / missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684a824b98e4832aabf8d4a722d347b4