### PR TITLE
Add send push notification function

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,10 @@ export default {
 - Replace `plugin:@typescript-eslint/recommended` to `plugin:@typescript-eslint/recommended-type-checked` or `plugin:@typescript-eslint/strict-type-checked`
 - Optionally add `plugin:@typescript-eslint/stylistic-type-checked`
 - Install [eslint-plugin-react](https://github.com/jsx-eslint/eslint-plugin-react) and add `plugin:react/recommended` & `plugin:react/jsx-runtime` to the `extends` list
+
+## Environment Variables
+
+The `send_push_notification` function requires the following variables:
+
+- `ONESIGNAL_APP_ID` - the OneSignal application ID.
+- `ONESIGNAL_API_KEY` - REST API key used to authorize requests.

--- a/supabase/functions/send_push_notification/deno.json
+++ b/supabase/functions/send_push_notification/deno.json
@@ -1,0 +1,5 @@
+{
+  "tasks": {
+    "start": "deno run --allow-net --allow-env --watch index.ts"
+  }
+}

--- a/supabase/functions/send_push_notification/index.ts
+++ b/supabase/functions/send_push_notification/index.ts
@@ -1,0 +1,54 @@
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers":
+    "authorization, x-client-info, apikey, content-type",
+};
+
+serve(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response("ok", { headers: corsHeaders });
+  }
+
+  try {
+    const { userId, title, message } = await req.json();
+
+    if (!userId || !title || !message) {
+      throw new Error("userId, title and message are required");
+    }
+
+    const response = await fetch(
+      "https://onesignal.com/api/v1/notifications",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "Authorization": `Basic ${Deno.env.get("ONESIGNAL_API_KEY")}`,
+        },
+        body: JSON.stringify({
+          app_id: Deno.env.get("ONESIGNAL_APP_ID"),
+          include_external_user_ids: [userId],
+          headings: { en: title },
+          contents: { en: message },
+        }),
+      },
+    );
+
+    const data = await response.json();
+
+    if (!response.ok) {
+      throw new Error(data.errors ? JSON.stringify(data.errors) : "Request failed");
+    }
+
+    return new Response(JSON.stringify({ success: true }), {
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+      status: 200,
+    });
+  } catch (error) {
+    return new Response(JSON.stringify({ error: error.message }), {
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+      status: 400,
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- add new `send_push_notification` Deno function
- document required OneSignal environment variables

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_684a7e9f8140832a8dd9deb364492f9b