### PR TITLE
Refactor dashboard pages to load user profile

### DIFF
--- a/src/pages/dashboard/help.tsx
+++ b/src/pages/dashboard/help.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import DashboardLayout from "@/components/layout/DashboardLayout";
 import {
   Card,
@@ -17,16 +17,28 @@ import {
   AccordionTrigger,
 } from "@/components/ui/accordion";
 import { MessageSquare, Phone, Mail, HelpCircle, Search } from "lucide-react";
+import { supabase } from "@/lib/supabaseClient";
 
 const HelpPage = () => {
-  // Mock user data - in a real app, this would come from authentication
-  const user = {
-    name: "John Smith",
-    email: "john.smith@example.com",
-    avatar: "https://api.dicebear.com/7.x/avataaars/svg?seed=John",
-    unreadMessages: 2,
-    unreadNotifications: 3,
-  };
+  const [user, setUser] = useState<any>(null);
+
+  useEffect(() => {
+    const fetchUser = async () => {
+      const { data } = await supabase.auth.getUser();
+      const userId = data.user?.id;
+      if (!userId) return;
+
+      const { data: profile } = await supabase
+        .from("profile_centra_resident")
+        .select("*")
+        .eq("id", userId)
+        .single();
+
+      setUser(profile);
+    };
+
+    fetchUser();
+  }, []);
 
   const [searchQuery, setSearchQuery] = useState("");
 
@@ -74,15 +86,10 @@ const HelpPage = () => {
       faq.answer.toLowerCase().includes(searchQuery.toLowerCase()),
   );
 
+  if (!user) return null;
+
   return (
-    <DashboardLayout
-      userType={
-        window.location.pathname.includes("tradie")
-          ? "tradie"
-          : "centraResident"
-      }
-      user={user}
-    >
+    <DashboardLayout userType="centraResident" user={user}>
       <div className="min-h-screen bg-gray-50">
         <div className="container mx-auto px-4 py-8">
           <div className="flex justify-between items-center mb-6">

--- a/src/pages/dashboard/rewards.tsx
+++ b/src/pages/dashboard/rewards.tsx
@@ -1,5 +1,6 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import DashboardLayout from "@/components/layout/DashboardLayout";
+import { supabase } from "@/lib/supabaseClient";
 import {
   Card,
   CardContent,
@@ -71,15 +72,27 @@ const mockRewards: RewardItem[] = [
 ];
 
 const RewardsPage = () => {
-  // Mock user data - in a real app, this would come from authentication
-  const user = {
-    name: "John Smith",
-    email: "john.smith@example.com",
-    avatar: "https://api.dicebear.com/7.x/avataaars/svg?seed=John",
-    unreadMessages: 2,
-    unreadNotifications: 3,
-    rewardPoints: 350,
-  };
+  const [user, setUser] = useState<any>(null);
+
+  useEffect(() => {
+    const fetchUser = async () => {
+      const { data } = await supabase.auth.getUser();
+      const userId = data.user?.id;
+      if (!userId) return;
+
+      const { data: profile } = await supabase
+        .from("profile_centra_resident")
+        .select("*")
+        .eq("id", userId)
+        .single();
+
+      setUser(profile);
+    };
+
+    fetchUser();
+  }, []);
+
+  if (!user) return null;
 
   return (
     <DashboardLayout userType="centraResident" user={user}>
@@ -90,7 +103,7 @@ const RewardsPage = () => {
             <div className="bg-primary/10 px-4 py-2 rounded-full flex items-center">
               <Gift className="h-5 w-5 mr-2 text-primary" />
               <span className="font-medium">
-                {user.rewardPoints} points available
+                {user.reward_points} points available
               </span>
             </div>
           </div>
@@ -149,19 +162,17 @@ const RewardsPage = () => {
                     </div>
                     <Button
                       variant={
-                        user.rewardPoints >= reward.pointCost
-                          ? "default"
-                          : "outline"
+                        user.reward_points >= reward.pointCost ? "default" : "outline"
                       }
-                      disabled={user.rewardPoints < reward.pointCost}
+                      disabled={user.reward_points < reward.pointCost}
                       onClick={() => {
-                        if (user.rewardPoints >= reward.pointCost) {
+                        if (user.reward_points >= reward.pointCost) {
                           // In a real app, this would call an API to redeem the reward
                           alert(`Reward ${reward.name} redeemed successfully!`);
                         }
                       }}
                     >
-                      {user.rewardPoints >= reward.pointCost
+                      {user.reward_points >= reward.pointCost
                         ? "Redeem"
                         : "Not Enough Points"}
                     </Button>

--- a/src/pages/dashboard/settings.tsx
+++ b/src/pages/dashboard/settings.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import DashboardLayout from "@/components/layout/DashboardLayout";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import {
@@ -15,18 +15,28 @@ import { Switch } from "@/components/ui/switch";
 import { Separator } from "@/components/ui/separator";
 import { toast } from "@/components/ui/use-toast";
 import ProfilePictureUploader from "@/components/settings/ProfilePictureUploader";
+import { supabase } from "@/lib/supabaseClient";
 
 const SettingsPage = () => {
-  // Mock user data - in a real app, this would come from authentication
-  const [user, setUser] = useState({
-    name: "John Smith",
-    email: "john.smith@example.com",
-    avatar: "https://api.dicebear.com/7.x/avataaars/svg?seed=John",
-    address: "123 Main St, Sydney, NSW 2000",
-    phone: "0412 345 678",
-    memberSince: "May 2023",
-    role: "homeowner",
-  });
+  const [user, setUser] = useState<any>(null);
+
+  useEffect(() => {
+    const fetchUser = async () => {
+      const { data } = await supabase.auth.getUser();
+      const userId = data.user?.id;
+      if (!userId) return;
+
+      const { data: profile } = await supabase
+        .from("profile_centra_resident")
+        .select("*")
+        .eq("id", userId)
+        .single();
+
+      setUser(profile);
+    };
+
+    fetchUser();
+  }, []);
 
   const handleAvatarChange = (newAvatarUrl: string) => {
     setUser((prev) => ({
@@ -60,11 +70,10 @@ const SettingsPage = () => {
     });
   };
 
+  if (!user) return null;
+
   return (
-    <DashboardLayout
-      userType={user.role === "homeowner" ? "centraResident" : "tradie"}
-      user={user}
-    >
+    <DashboardLayout userType="centraResident" user={user}>
       <div className="container mx-auto px-4 py-8">
         <h1 className="text-2xl font-bold mb-6">Settings</h1>
 

--- a/src/pages/dashboard/tradie/find-jobs.tsx
+++ b/src/pages/dashboard/tradie/find-jobs.tsx
@@ -26,6 +26,7 @@ const FindJobsPage = () => {
   const [showEmergencyOnly, setShowEmergencyOnly] = useState(false);
   const [purchasedLeads, setPurchasedLeads] = useState<string[]>([]);
   const [userId, setUserId] = useState<string>("");
+  const [user, setUser] = useState<any>(null);
   const navigate = useNavigate();
 
   const fetchJobs = async () => {
@@ -34,6 +35,14 @@ const FindJobsPage = () => {
     } = await supabase.auth.getUser();
     if (!user) return;
     setUserId(user.id);
+
+    const { data: profile } = await supabase
+      .from("profile_centra_tradie")
+      .select("*")
+      .eq("id", user.id)
+      .single();
+
+    setUser(profile);
 
     const { data: leadsData } = await supabase
       .from("job_leads")
@@ -113,8 +122,10 @@ const FindJobsPage = () => {
     );
   });
 
+  if (!user) return null;
+
   return (
-    <DashboardLayout userType="tradie" user={{ name: "Tradie" }}>
+    <DashboardLayout userType="tradie" user={user}>
       <div className="p-6">
         <h1 className="text-2xl font-bold mb-4">Find Jobs</h1>
         <div className="mb-4">

--- a/src/pages/dashboard/tradie/help.tsx
+++ b/src/pages/dashboard/tradie/help.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import DashboardLayout from "@/components/layout/DashboardLayout";
 import {
   Card,
@@ -17,17 +17,28 @@ import {
   AccordionTrigger,
 } from "@/components/ui/accordion";
 import { MessageSquare, Phone, Mail, HelpCircle, Search } from "lucide-react";
+import { supabase } from "@/lib/supabaseClient";
 
 const TradieHelpPage = () => {
-  // Mock user data - in a real app, this would come from authentication
-  const user = {
-    name: "Mike Johnson",
-    email: "mike.johnson@example.com",
-    avatar: "https://api.dicebear.com/7.x/avataaars/svg?seed=Mike",
-    trade: "Plumber",
-    unreadMessages: 1,
-    unreadNotifications: 2,
-  };
+  const [user, setUser] = useState<any>(null);
+
+  useEffect(() => {
+    const fetchUser = async () => {
+      const { data } = await supabase.auth.getUser();
+      const userId = data.user?.id;
+      if (!userId) return;
+
+      const { data: profile } = await supabase
+        .from("profile_centra_tradie")
+        .select("*")
+        .eq("id", userId)
+        .single();
+
+      setUser(profile);
+    };
+
+    fetchUser();
+  }, []);
 
   const [searchQuery, setSearchQuery] = useState("");
 
@@ -74,6 +85,8 @@ const TradieHelpPage = () => {
       faq.question.toLowerCase().includes(searchQuery.toLowerCase()) ||
       faq.answer.toLowerCase().includes(searchQuery.toLowerCase()),
   );
+
+  if (!user) return null;
 
   return (
     <DashboardLayout userType="tradie" user={user}>

--- a/src/pages/dashboard/tradie/settings.tsx
+++ b/src/pages/dashboard/tradie/settings.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import DashboardLayout from "@/components/layout/DashboardLayout";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import {
@@ -15,21 +15,28 @@ import { Switch } from "@/components/ui/switch";
 import { Separator } from "@/components/ui/separator";
 import { toast } from "@/components/ui/use-toast";
 import ProfilePictureUploader from "@/components/settings/ProfilePictureUploader";
+import { supabase } from "@/lib/supabaseClient";
 
 const TradieSettingsPage = () => {
-  // Mock user data - in a real app, this would come from authentication
-  const [user, setUser] = useState({
-    name: "Mike Johnson",
-    email: "mike.johnson@example.com",
-    avatar: "https://api.dicebear.com/7.x/avataaars/svg?seed=Mike",
-    trade: "Plumber",
-    license: "PL-12345",
-    abn: "12 345 678 901",
-    address: "456 Tradie St, Sydney, NSW 2000",
-    phone: "0412 345 678",
-    memberSince: "January 2023",
-    role: "tradie",
-  });
+  const [user, setUser] = useState<any>(null);
+
+  useEffect(() => {
+    const fetchUser = async () => {
+      const { data } = await supabase.auth.getUser();
+      const userId = data.user?.id;
+      if (!userId) return;
+
+      const { data: profile } = await supabase
+        .from("profile_centra_tradie")
+        .select("*")
+        .eq("id", userId)
+        .single();
+
+      setUser(profile);
+    };
+
+    fetchUser();
+  }, []);
 
   const handleAvatarChange = (newAvatarUrl: string) => {
     setUser((prev) => ({
@@ -70,6 +77,8 @@ const TradieSettingsPage = () => {
       description: "Your business information has been updated successfully",
     });
   };
+
+  if (!user) return null;
 
   return (
     <DashboardLayout userType="tradie" user={user}>

--- a/src/pages/dashboard/tradie/top-tradies.tsx
+++ b/src/pages/dashboard/tradie/top-tradies.tsx
@@ -48,6 +48,7 @@ const getRankClass = (rank: number) => {
 
 const TopTradiesPage = () => {
   const [tradies, setTradies] = useState<any[]>([]);
+  const [user, setUser] = useState<any>(null);
 
   useEffect(() => {
     const fetchTopTradies = async () => {
@@ -61,11 +62,28 @@ const TopTradiesPage = () => {
         setTradies(data);
       }
     };
+    const fetchUser = async () => {
+      const { data } = await supabase.auth.getUser();
+      const userId = data.user?.id;
+      if (!userId) return;
+
+      const { data: profile } = await supabase
+        .from("profile_centra_tradie")
+        .select("*")
+        .eq("id", userId)
+        .single();
+
+      setUser(profile);
+    };
+
     fetchTopTradies();
+    fetchUser();
   }, []);
 
+  if (!user) return null;
+
   return (
-    <DashboardLayout userType="tradie">
+    <DashboardLayout userType="tradie" user={user}>
       <div className="p-6 max-w-5xl mx-auto">
         <div className="flex justify-between items-center mb-6">
           <h1 className="text-2xl font-bold">Top Tradies</h1>


### PR DESCRIPTION
## Summary
- load current user's profile from Supabase on several dashboard pages
- pass loaded profile to `DashboardLayout`
- set correct `userType` for homeowner and tradie pages

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_684a8c6ca46c832ab83dc2a3704f1418