### PR TITLE
Remove verbose Supabase logs

### DIFF
--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -5,8 +5,6 @@ const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
 
 if (!supabaseUrl || !supabaseAnonKey) {
   console.warn('Supabase environment variables are missing!');
-  console.log('VITE_SUPABASE_URL:', supabaseUrl);
-  console.log('VITE_SUPABASE_ANON_KEY:', supabaseAnonKey);
 }
 
 // ✅ Create and export your Supabase client with global headers


### PR DESCRIPTION
## Summary
- tidy the Supabase client by deleting console.log statements
- keep a generic warning if environment variables are missing

## Testing
- `npm run lint` *(fails: config error)*

------
https://chatgpt.com/codex/tasks/task_e_684ab6738a28832ab3fa44df9ae71034