### PR TITLE
Use env variable for OneSignal app ID

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# Example environment variables for LOCENTRA
+# Provide your OneSignal application ID for push notifications
+VITE_ONESIGNAL_APP_ID=
+# Server function environment variable for OneSignal
+ONESIGNAL_REST_API_KEY=

--- a/src/components/OneSignalInit.tsx
+++ b/src/components/OneSignalInit.tsx
@@ -8,6 +8,11 @@ declare global {
 }
 
 const OneSignalInit = () => {
+  const appId = import.meta.env.VITE_ONESIGNAL_APP_ID;
+  if (!appId) {
+    console.warn("VITE_ONESIGNAL_APP_ID is not set");
+  }
+
   useEffect(() => {
     const loadOneSignal = () => {
       if (window.OneSignal) return;
@@ -20,7 +25,7 @@ const OneSignalInit = () => {
         window.OneSignal = window.OneSignal || [];
         window.OneSignal.push(function () {
           window.OneSignal.init({
-            appId: "b6d82074-2797-435a-9586-63bc0b55a696", // ✅ your correct OneSignal app ID
+            appId: appId,
             notifyButton: {
               enable: true,
             },


### PR DESCRIPTION
## Summary
- inject the OneSignal app ID from an env var in `OneSignalInit`
- add `.env.example` with the env variable

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684ab683a160832aaec8044eb851fd6a