### PR TITLE
Disable chat actions without conversation

### DIFF
--- a/src/pages/dashboard/messages.tsx
+++ b/src/pages/dashboard/messages.tsx
@@ -195,7 +195,13 @@ const HomeownerMessagesPage = () => {
         <div className="col-span-2">
           <h2 className="text-lg font-semibold mb-2">Messages</h2>
           <div className="border rounded p-4 bg-white h-[500px] overflow-y-auto">
-            {messages.map((msg) => (
+            {!selectedConversationId && (
+              <div className="text-center text-muted-foreground text-sm">
+                Select a conversation to start chatting.
+              </div>
+            )}
+            {selectedConversationId &&
+              messages.map((msg) => (
               <div
                 key={msg.id}
                 className={`my-2 max-w-sm px-4 py-2 rounded-lg ${
@@ -217,24 +223,32 @@ const HomeownerMessagesPage = () => {
             <div ref={bottomRef} />
           </div>
 
-          <div className="flex gap-2 mt-4">
-            <Input
-              value={newMessage}
-              onChange={(e) => setNewMessage(e.target.value)}
-              placeholder="Type a message..."
-            />
-            <input
-              type="file"
-              accept="image/*"
-              ref={fileInputRef}
-              hidden
-              onChange={handleImageUpload}
-            />
-            <Button onClick={() => fileInputRef.current?.click()}>📷</Button>
-            <Button onClick={handleSend} disabled={!newMessage.trim()}>
+            <div className="flex gap-2 mt-4">
+              <Input
+                value={newMessage}
+                onChange={(e) => setNewMessage(e.target.value)}
+                placeholder="Type a message..."
+              />
+              <input
+                type="file"
+                accept="image/*"
+                ref={fileInputRef}
+                hidden
+                onChange={handleImageUpload}
+              />
+            <Button
+              onClick={() => fileInputRef.current?.click()}
+              disabled={!selectedConversationId}
+            >
+              📷
+            </Button>
+            <Button
+              onClick={handleSend}
+              disabled={!newMessage.trim() || !selectedConversationId}
+            >
               Send
             </Button>
-          </div>
+            </div>
         </div>
       </div>
     </DashboardLayout>

--- a/src/pages/dashboard/tradie/messages.tsx
+++ b/src/pages/dashboard/tradie/messages.tsx
@@ -188,7 +188,13 @@ const MessagesPage = () => {
         <div className="flex-1 border rounded p-4 bg-white h-[600px] flex flex-col">
           <h2 className="font-semibold text-lg mb-2">Messages</h2>
           <div className="flex-1 overflow-y-auto space-y-2">
-            {messages.map((msg) => (
+            {!selectedConversation && (
+              <div className="text-center text-muted-foreground text-sm">
+                Select a conversation to start chatting.
+              </div>
+            )}
+            {selectedConversation &&
+              messages.map((msg) => (
               <div
                 key={msg.id}
                 className={`max-w-xs px-4 py-2 rounded-lg ${
@@ -205,7 +211,7 @@ const MessagesPage = () => {
                 )}
               </div>
             ))}
-            {!canMessage && (
+            {!selectedConversation && !messages.length ? null : !canMessage && (
               <div className="text-center text-muted-foreground text-sm mt-4">
                 You cannot message anymore. The job has been assigned to another tradie.
               </div>
@@ -227,8 +233,16 @@ const MessagesPage = () => {
               hidden
               onChange={handleImageUpload}
             />
-            <Button onClick={() => fileInputRef.current?.click()} disabled={!canMessage}>📷</Button>
-            <Button onClick={handleSend} disabled={!newMessage.trim() || !canMessage}>
+            <Button
+              onClick={() => fileInputRef.current?.click()}
+              disabled={!selectedConversation || !canMessage}
+            >
+              📷
+            </Button>
+            <Button
+              onClick={handleSend}
+              disabled={!newMessage.trim() || !selectedConversation || !canMessage}
+            >
               Send
             </Button>
           </div>


### PR DESCRIPTION
## Summary
- prevent image upload and message send unless a conversation is picked
- prompt user to pick a conversation

## Testing
- `npm run lint` *(fails: A config object is using the "root" key, which is not supported in flat config system)*

------
https://chatgpt.com/codex/tasks/task_e_684abb3be438832a94f0b7f17eab6649