### PR TITLE
Add markMessagesAsRead for chat

### DIFF
--- a/src/components/layout/DashboardLayout.tsx
+++ b/src/components/layout/DashboardLayout.tsx
@@ -47,6 +47,7 @@ const DashboardLayout: React.FC<DashboardLayoutProps> = ({
       .from("messages")
       .select("*", { count: "exact", head: true })
       .eq(msgField, user.id)
+      .neq("sender_id", user.id)
       .eq("is_read", false);
 
     const { count: notifCount } = await supabase

--- a/src/components/layout/DashboardLayout.tsx
+++ b/src/components/layout/DashboardLayout.tsx
@@ -82,6 +82,18 @@ const DashboardLayout: React.FC<DashboardLayoutProps> = ({
           fetchUnreadCounts();
         }
       )
+      .on(
+        "postgres_changes",
+        {
+          event: "UPDATE",
+          schema: "public",
+          table: "messages",
+          filter: `${msgField}=eq.${user.id}`,
+        },
+        () => {
+          fetchUnreadCounts();
+        }
+      )
       .subscribe();
 
     const notifChannel = supabase

--- a/src/pages/dashboard/messages.tsx
+++ b/src/pages/dashboard/messages.tsx
@@ -124,7 +124,7 @@ const HomeownerMessagesPage = () => {
     if (!file || !userId || !selectedConversationId) return;
 
     const ext = file.name.split(".").pop();
-    const filePath = `chat-images/${selectedConversationId}/${Date.now()}.${ext}`;
+    const filePath = `${selectedConversationId}/${Date.now()}.${ext}`;
 
     const { error: uploadError } = await supabase.storage
       .from("chat-images")

--- a/src/pages/dashboard/messages.tsx
+++ b/src/pages/dashboard/messages.tsx
@@ -20,6 +20,16 @@ const HomeownerMessagesPage = () => {
   const fileInputRef = useRef<HTMLInputElement>(null);
   const bottomRef = useRef<HTMLDivElement>(null);
 
+  const markMessagesAsRead = async () => {
+    if (!selectedConversationId || !userId) return;
+    await supabase
+      .from("messages")
+      .update({ is_read: true })
+      .eq("conversation_id", selectedConversationId)
+      .neq("sender_id", userId)
+      .eq("is_read", false);
+  };
+
   useEffect(() => {
     const fetchUserAndProfile = async () => {
       const { data } = await supabase.auth.getUser();
@@ -66,6 +76,7 @@ const HomeownerMessagesPage = () => {
       if (!error) {
         setMessages(data || []);
         bottomRef.current?.scrollIntoView({ behavior: "smooth" });
+        markMessagesAsRead();
       }
     };
 
@@ -84,6 +95,7 @@ const HomeownerMessagesPage = () => {
         (payload) => {
           setMessages((prev) => [...prev, payload.new]);
           bottomRef.current?.scrollIntoView({ behavior: "smooth" });
+          markMessagesAsRead();
         }
       )
       .subscribe();

--- a/src/pages/dashboard/tradie/messages.tsx
+++ b/src/pages/dashboard/tradie/messages.tsx
@@ -16,6 +16,16 @@ const MessagesPage = () => {
   const bottomRef = useRef<HTMLDivElement>(null);
   const [profile, setProfile] = useState<any>(null);
 
+  const markMessagesAsRead = async () => {
+    if (!selectedConversation?.id || !userId) return;
+    await supabase
+      .from("messages")
+      .update({ is_read: true })
+      .eq("conversation_id", selectedConversation.id)
+      .neq("sender_id", userId)
+      .eq("is_read", false);
+  };
+
   useEffect(() => {
     const fetchUserAndConversations = async () => {
       const {
@@ -56,6 +66,7 @@ const MessagesPage = () => {
       if (!error) {
         setMessages(data || []);
         bottomRef.current?.scrollIntoView({ behavior: "smooth" });
+        markMessagesAsRead();
       }
     };
 
@@ -74,6 +85,7 @@ const MessagesPage = () => {
         (payload) => {
           setMessages((prev) => [...prev, payload.new]);
           bottomRef.current?.scrollIntoView({ behavior: "smooth" });
+          markMessagesAsRead();
         }
       )
       .subscribe();

--- a/src/pages/dashboard/tradie/messages.tsx
+++ b/src/pages/dashboard/tradie/messages.tsx
@@ -114,7 +114,7 @@ const MessagesPage = () => {
     if (!file || !userId || !selectedConversation?.id) return;
 
     const ext = file.name.split(".").pop();
-    const filePath = `chat-images/${selectedConversation.id}/${Date.now()}.${ext}`;
+    const filePath = `${selectedConversation.id}/${Date.now()}.${ext}`;
 
     const { error: uploadError } = await supabase.storage
       .from("chat-images")


### PR DESCRIPTION
## Summary
- mark all incoming messages as read on homeowner message page
- mark all incoming messages as read on tradie message page

## Testing
- `npm run lint` *(fails: A config object is using the "root" key)*

------
https://chatgpt.com/codex/tasks/task_e_684abcdc0da0832a8b6c1a10615f8050