### PR TITLE
Add error logging on image message insert

### DIFF
--- a/src/components/messaging/ChatWindow.tsx
+++ b/src/components/messaging/ChatWindow.tsx
@@ -99,7 +99,12 @@ const ChatWindow: React.FC<ChatWindowProps> = ({ conversation, user, userType })
         userType === "centraResident" ? user.id : conversation.homeowner_id ?? null,
     };
 
-    await supabase.from("messages").insert(messagePayload);
+    const { error } = await supabase
+      .from("messages")
+      .insert(messagePayload);
+    if (error) {
+      console.error("Failed to save image message:", error.message);
+    }
   };
 
   return (

--- a/src/pages/dashboard/messages.tsx
+++ b/src/pages/dashboard/messages.tsx
@@ -127,11 +127,14 @@ const HomeownerMessagesPage = () => {
       .from("chat-images")
       .getPublicUrl(filePath);
 
-    await supabase.from("messages").insert({
+    const { error: insertError } = await supabase.from("messages").insert({
       conversation_id: selectedConversationId,
       sender_id: userId,
       image_url: data.publicUrl,
     });
+    if (insertError) {
+      console.error("Failed to save image message:", insertError.message);
+    }
 
     e.target.value = "";
   };

--- a/src/pages/dashboard/tradie/messages.tsx
+++ b/src/pages/dashboard/tradie/messages.tsx
@@ -115,11 +115,14 @@ const MessagesPage = () => {
 
     const { data } = supabase.storage.from("chat-images").getPublicUrl(filePath);
 
-    await supabase.from("messages").insert({
+    const { error: insertError } = await supabase.from("messages").insert({
       conversation_id: selectedConversation.id,
       sender_id: userId,
       image_url: data.publicUrl,
     });
+    if (insertError) {
+      console.error("Failed to save image message:", insertError.message);
+    }
 
     e.target.value = "";
   };


### PR DESCRIPTION
## Summary
- log insert errors when sending images in ChatWindow
- check for insert errors when uploading images in tradie and homeowner message pages

## Testing
- `npm run lint` *(fails: A config object is using the "root" key, which is not supported in flat config system)*

------
https://chatgpt.com/codex/tasks/task_e_684ac33737a8832a994b757a411e2d8e