### PR TITLE
Add is_read flag to message inserts

### DIFF
--- a/src/components/messaging/MessageInput.tsx
+++ b/src/components/messaging/MessageInput.tsx
@@ -54,6 +54,7 @@ const MessageInput: React.FC<MessageInputProps> = ({ conversationId }) => {
       sender_id: currentUserId,
       content: message,
       image_url: imageUrl,
+      is_read: false,
     });
 
     if (error) {

--- a/src/components/messaging/MessagingSystem.tsx
+++ b/src/components/messaging/MessagingSystem.tsx
@@ -117,6 +117,7 @@ const MessagingSystem = ({ userId, userName, userAvatar, userType }: Props) => {
       conversation_id: activeConversationId,
       sender_id: userId,
       message: newMessage.trim(),
+      is_read: false,
     });
 
     if (!error) {

--- a/src/components/messaging/SimpleMessagingSystem.tsx
+++ b/src/components/messaging/SimpleMessagingSystem.tsx
@@ -86,6 +86,7 @@ const SimpleMessagingSystem: React.FC<SimpleMessagingSystemProps> = ({
       conversation_id: conversationId,
       sender_id: userId,
       message: newMessage.trim(),
+      is_read: false,
     });
 
     if (!error) setNewMessage("");

--- a/src/pages/dashboard/find-jobs.tsx
+++ b/src/pages/dashboard/find-jobs.tsx
@@ -106,6 +106,7 @@ const FindJobsPage = () => {
       conversation_id: conversation.id,
       sender_id: tradieId,
       message: autoMessage,
+      is_read: false,
     });
 
     await fetchJobs();

--- a/src/pages/dashboard/messages.tsx
+++ b/src/pages/dashboard/messages.tsx
@@ -100,6 +100,7 @@ const HomeownerMessagesPage = () => {
       conversation_id: selectedConversationId,
       sender_id: userId,
       message: newMessage.trim(),
+      is_read: false,
     });
 
     if (!error) {
@@ -131,6 +132,7 @@ const HomeownerMessagesPage = () => {
       conversation_id: selectedConversationId,
       sender_id: userId,
       image_url: data.publicUrl,
+      is_read: false,
     });
 
     e.target.value = "";

--- a/src/pages/dashboard/tradie/find-jobs.tsx
+++ b/src/pages/dashboard/tradie/find-jobs.tsx
@@ -95,6 +95,7 @@ const FindJobsPage = () => {
       conversation_id: conversation.id,
       sender_id: tradieId,
       message: autoMessage,
+      is_read: false,
     });
 
     await fetchJobs();

--- a/src/pages/dashboard/tradie/messages.tsx
+++ b/src/pages/dashboard/tradie/messages.tsx
@@ -90,6 +90,7 @@ const MessagesPage = () => {
       conversation_id: selectedConversation.id,
       sender_id: userId,
       message: newMessage.trim(),
+      is_read: false,
     });
 
     if (!error) {
@@ -119,6 +120,7 @@ const MessagesPage = () => {
       conversation_id: selectedConversation.id,
       sender_id: userId,
       image_url: data.publicUrl,
+      is_read: false,
     });
 
     e.target.value = "";


### PR DESCRIPTION
## Summary
- mark messages as unread on insert across the app

## Testing
- `npm run lint` *(fails: root key not supported)*
- `npm run build-no-errors` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ac32ee804832ab404ea9127b55b2e