### PR TITLE
Fix message field name

### DIFF
--- a/src/components/messaging/MessageInput.tsx
+++ b/src/components/messaging/MessageInput.tsx
@@ -52,7 +52,7 @@ const MessageInput: React.FC<MessageInputProps> = ({ conversationId }) => {
     const { error } = await supabase.from("messages").insert({
       conversation_id: conversationId,
       sender_id: currentUserId,
-      content: message,
+      message: message,
       image_url: imageUrl,
     });
 

--- a/src/components/messaging/useMessages.tsx
+++ b/src/components/messaging/useMessages.tsx
@@ -5,7 +5,7 @@ interface Message {
   id: string;
   conversation_id: string;
   sender_id: string;
-  content: string;
+  message: string;
   image_url?: string;
   created_at: string;
   avatar_url?: string; // optional if you include avatars later


### PR DESCRIPTION
## Summary
- align message text column usage across messaging components

## Testing
- `npm run lint` *(fails: A config object is using the "root" key, which is not supported in flat config system)*

------
https://chatgpt.com/codex/tasks/task_e_684ac7694750832aa785989d8c54ec86