### PR TITLE
Implement read receipts for messaging

### DIFF
--- a/src/components/layout/DashboardLayout.tsx
+++ b/src/components/layout/DashboardLayout.tsx
@@ -47,7 +47,8 @@ const DashboardLayout: React.FC<DashboardLayoutProps> = ({
       .from("messages")
       .select("*", { count: "exact", head: true })
       .eq(msgField, user.id)
-      .eq("is_read", false);
+      .not("sender_id", "eq", user.id)
+      .or("is_read.eq.false,is_read.is.null");
 
     const { count: notifCount } = await supabase
       .from("notifications")

--- a/src/components/layout/DashboardLayout.tsx
+++ b/src/components/layout/DashboardLayout.tsx
@@ -65,6 +65,13 @@ const DashboardLayout: React.FC<DashboardLayoutProps> = ({
   }, [user?.id, userType]);
 
   useEffect(() => {
+    window.addEventListener("refreshUnread", fetchUnreadCounts);
+    return () => {
+      window.removeEventListener("refreshUnread", fetchUnreadCounts);
+    };
+  }, [user?.id, userType]);
+
+  useEffect(() => {
     if (!user?.id) return;
     const msgField = userType === "centraResident" ? "homeowner_id" : "tradie_id";
 

--- a/src/components/messaging/ChatWindow.tsx
+++ b/src/components/messaging/ChatWindow.tsx
@@ -9,7 +9,7 @@ const markMessagesAsRead = async (conversationId: string, userId: string) => {
     .update({ is_read: true })
     .eq("conversation_id", conversationId)
     .not("sender_id", "eq", userId)
-    .eq("is_read", false);
+    .or("is_read.eq.false,is_read.is.null");
   window.dispatchEvent(new Event("refreshUnread"));
 };
 

--- a/src/pages/dashboard/messages.tsx
+++ b/src/pages/dashboard/messages.tsx
@@ -13,7 +13,7 @@ const markMessagesAsRead = async (conversationId: string, userId: string) => {
     .update({ is_read: true })
     .eq("conversation_id", conversationId)
     .not("sender_id", "eq", userId)
-    .eq("is_read", false);
+    .or("is_read.eq.false,is_read.is.null");
   window.dispatchEvent(new Event("refreshUnread"));
 };
 
@@ -116,6 +116,7 @@ const HomeownerMessagesPage = () => {
       conversation_id: selectedConversationId,
       sender_id: userId,
       message: newMessage.trim(),
+      is_read: false,
     });
 
     if (!error) {
@@ -147,6 +148,7 @@ const HomeownerMessagesPage = () => {
       conversation_id: selectedConversationId,
       sender_id: userId,
       image_url: data.publicUrl,
+      is_read: false,
     });
 
     e.target.value = "";

--- a/src/pages/dashboard/tradie/messages.tsx
+++ b/src/pages/dashboard/tradie/messages.tsx
@@ -12,7 +12,7 @@ const markMessagesAsRead = async (conversationId: string, userId: string) => {
     .update({ is_read: true })
     .eq("conversation_id", conversationId)
     .not("sender_id", "eq", userId)
-    .eq("is_read", false);
+    .or("is_read.eq.false,is_read.is.null");
   window.dispatchEvent(new Event("refreshUnread"));
 };
 
@@ -106,6 +106,7 @@ const MessagesPage = () => {
       conversation_id: selectedConversation.id,
       sender_id: userId,
       message: newMessage.trim(),
+      is_read: false,
     });
 
     if (!error) {
@@ -135,6 +136,7 @@ const MessagesPage = () => {
       conversation_id: selectedConversation.id,
       sender_id: userId,
       image_url: data.publicUrl,
+      is_read: false,
     });
 
     e.target.value = "";


### PR DESCRIPTION
## Summary
- update Homeowner and Tradie message pages to mark messages as read
- add same logic in `ChatWindow`
- refresh unread badge counts via a `refreshUnread` event

## Testing
- `npm run lint` *(fails: config error)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ac7552e98832a9c3c5e12ccee2a7f