### PR TITLE
Include metadata with messages

### DIFF
--- a/src/components/messaging/MessageInput.tsx
+++ b/src/components/messaging/MessageInput.tsx
@@ -13,6 +13,7 @@ const MessageInput: React.FC<MessageInputProps> = ({ conversationId }) => {
   const [message, setMessage] = useState("");
   const [file, setFile] = useState<File | null>(null);
   const [loading, setLoading] = useState(false);
+  const [conversation, setConversation] = useState<{tradie_id:string;homeowner_id:string} | null>(null);
 
   useEffect(() => {
     const fetchUser = async () => {
@@ -20,6 +21,15 @@ const MessageInput: React.FC<MessageInputProps> = ({ conversationId }) => {
       if (user) setCurrentUserId(user.id);
     };
     fetchUser();
+    const fetchConversation = async () => {
+      const { data } = await supabase
+        .from("conversations")
+        .select("tradie_id, homeowner_id")
+        .eq("id", conversationId)
+        .single();
+      setConversation(data as any);
+    };
+    fetchConversation();
   }, []);
 
   const sendMessage = async () => {
@@ -54,6 +64,9 @@ const MessageInput: React.FC<MessageInputProps> = ({ conversationId }) => {
       sender_id: currentUserId,
       content: message,
       image_url: imageUrl,
+      tradie_id: conversation?.tradie_id ?? null,
+      homeowner_id: conversation?.homeowner_id ?? null,
+      is_read: false,
     });
 
     if (error) {

--- a/src/components/messaging/MessagingSystem.tsx
+++ b/src/components/messaging/MessagingSystem.tsx
@@ -113,10 +113,15 @@ const MessagingSystem = ({ userId, userName, userAvatar, userType }: Props) => {
   const handleSend = async () => {
     if (!newMessage.trim() || !userId || !activeConversationId) return;
 
+    const conv = conversations.find((c) => c.id === activeConversationId);
+
     const { error } = await supabase.from("messages").insert({
       conversation_id: activeConversationId,
       sender_id: userId,
       message: newMessage.trim(),
+      tradie_id: conv?.tradie_id ?? null,
+      homeowner_id: conv?.homeowner_id ?? null,
+      is_read: false,
     });
 
     if (!error) {

--- a/src/pages/dashboard/find-jobs.tsx
+++ b/src/pages/dashboard/find-jobs.tsx
@@ -106,6 +106,9 @@ const FindJobsPage = () => {
       conversation_id: conversation.id,
       sender_id: tradieId,
       message: autoMessage,
+      tradie_id: tradieId,
+      homeowner_id: job.homeowner_id,
+      is_read: false,
     });
 
     await fetchJobs();

--- a/src/pages/dashboard/messages.tsx
+++ b/src/pages/dashboard/messages.tsx
@@ -44,7 +44,9 @@ const HomeownerMessagesPage = () => {
     const fetchConversations = async () => {
       const { data, error } = await supabase
         .from("conversations")
-        .select("id, jobs(title), profile_centra_tradie(first_name, avatar_url)")
+        .select(
+          "id, tradie_id, homeowner_id, jobs(title), profile_centra_tradie(first_name, avatar_url)"
+        )
         .eq("homeowner_id", userId);
 
       if (!error) setConversations(data || []);
@@ -96,10 +98,15 @@ const HomeownerMessagesPage = () => {
   const handleSend = async () => {
     if (!newMessage.trim() || !userId || !selectedConversationId) return;
 
+    const conv = conversations.find((c) => c.id === selectedConversationId);
+
     const { error } = await supabase.from("messages").insert({
       conversation_id: selectedConversationId,
       sender_id: userId,
       message: newMessage.trim(),
+      tradie_id: conv?.tradie_id || null,
+      homeowner_id: conv?.homeowner_id || null,
+      is_read: false,
     });
 
     if (!error) {
@@ -110,6 +117,8 @@ const HomeownerMessagesPage = () => {
   const handleImageUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (!file || !userId || !selectedConversationId) return;
+
+    const conv = conversations.find((c) => c.id === selectedConversationId);
 
     const ext = file.name.split(".").pop();
     const filePath = `chat-images/${selectedConversationId}/${Date.now()}.${ext}`;
@@ -131,6 +140,9 @@ const HomeownerMessagesPage = () => {
       conversation_id: selectedConversationId,
       sender_id: userId,
       image_url: data.publicUrl,
+      tradie_id: conv?.tradie_id || null,
+      homeowner_id: conv?.homeowner_id || null,
+      is_read: false,
     });
 
     e.target.value = "";

--- a/src/pages/dashboard/tradie/find-jobs.tsx
+++ b/src/pages/dashboard/tradie/find-jobs.tsx
@@ -95,6 +95,9 @@ const FindJobsPage = () => {
       conversation_id: conversation.id,
       sender_id: tradieId,
       message: autoMessage,
+      tradie_id: tradieId,
+      homeowner_id: job.homeowner_id,
+      is_read: false,
     });
 
     await fetchJobs();

--- a/src/pages/dashboard/tradie/messages.tsx
+++ b/src/pages/dashboard/tradie/messages.tsx
@@ -90,6 +90,9 @@ const MessagesPage = () => {
       conversation_id: selectedConversation.id,
       sender_id: userId,
       message: newMessage.trim(),
+      tradie_id: selectedConversation.tradie_id,
+      homeowner_id: selectedConversation.homeowner_id,
+      is_read: false,
     });
 
     if (!error) {
@@ -119,6 +122,9 @@ const MessagesPage = () => {
       conversation_id: selectedConversation.id,
       sender_id: userId,
       image_url: data.publicUrl,
+      tradie_id: selectedConversation.tradie_id,
+      homeowner_id: selectedConversation.homeowner_id,
+      is_read: false,
     });
 
     e.target.value = "";


### PR DESCRIPTION
## Summary
- expand conversation fetching for resident messages page
- attach sender/recipient IDs and read flag when sending from resident page
- add message metadata for tradie pages
- ensure auto-messages store IDs when leads purchased
- update messaging utilities to include IDs and read flag

## Testing
- `npm run build-no-errors`

------
https://chatgpt.com/codex/tasks/task_e_684acd3523ec832a85f40453a5f93fd9