### PR TITLE
Fix ESLint root property

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,5 +1,4 @@
 module.exports = {
-  root: true,
   parser: '@typescript-eslint/parser',
   plugins: ['@typescript-eslint'],
   extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended'],


### PR DESCRIPTION
## Summary
- remove deprecated `root` key from ESLint config
- run `npm run lint` to verify config

## Testing
- `npm run lint` *(fails: Unexpected any etc.)*

------
https://chatgpt.com/codex/tasks/task_e_684ae5268a30832aa1d1b2c3a7a54bd0