### PR TITLE
Fix drawer position below header

### DIFF
--- a/src/components/ui/drawer.tsx
+++ b/src/components/ui/drawer.tsx
@@ -41,7 +41,7 @@ const DrawerContent = React.forwardRef<
     <DrawerPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed inset-x-0 bottom-0 z-50 mt-24 flex h-auto flex-col rounded-t-[10px] border bg-background",
+        "fixed inset-x-0 bottom-0 z-50 mt-16 flex h-auto flex-col rounded-t-[10px] border bg-background",
         className
       )}
       {...props}


### PR DESCRIPTION
## Summary
- adjust drawer margin so it sits directly under the header

## Testing
- `npm run lint` *(fails: "A config object is using the 'parser' key, which is not supported in flat config system")*

------
https://chatgpt.com/codex/tasks/task_e_684aed37e4e0832a8876e5d93e31699f