### PR TITLE
Fix push notifications via OneSignal

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,7 @@
 # Example environment variables for LOCENTRA
-# Provide your OneSignal application ID for push notifications
+# Provide your OneSignal application ID for the front end
 VITE_ONESIGNAL_APP_ID=
-# Server function environment variable for OneSignal
+
+# Serverless function environment variables for OneSignal
+ONESIGNAL_APP_ID=
 ONESIGNAL_REST_API_KEY=

--- a/src/components/OneSignalInit.tsx
+++ b/src/components/OneSignalInit.tsx
@@ -1,5 +1,6 @@
 // src/components/OneSignalInit.tsx
 import { useEffect } from "react";
+import { savePlayerId } from "@/lib/notification";
 
 declare global {
   interface Window {
@@ -35,6 +36,19 @@ const OneSignalInit = () => {
               acceptButtonText: "Yes",
               cancelButtonText: "No",
             },
+          });
+
+          window.OneSignal.on('subscriptionChange', async (isSubscribed: boolean) => {
+            if (isSubscribed) {
+              try {
+                const id = await window.OneSignal.getUserId();
+                if (id) {
+                  await savePlayerId(id);
+                }
+              } catch (err) {
+                console.error('Failed to save OneSignal player ID', err);
+              }
+            }
           });
 
           // Optionally prompt the user manually (or remove this block if you only want auto-prompt)

--- a/src/components/reviews/ReviewForm.tsx
+++ b/src/components/reviews/ReviewForm.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import { supabase } from "@/lib/supabaseClient";
+import { sendPushNotification } from "@/lib/notification";
 import { Textarea } from "@/components/ui/textarea";
 import { Button } from "@/components/ui/button";
 import { Star } from "lucide-react";
@@ -71,6 +72,24 @@ const ReviewForm: React.FC<ReviewFormProps> = ({ jobId, tradieId, jobTitle }) =>
       related_id: jobId,
       related_type: "job",
     });
+
+    const { data: tradieProfile } = await supabase
+      .from("profile_centra_tradie")
+      .select("onesignal_player_id")
+      .eq("id", tradieId)
+      .single();
+
+    const playerId = tradieProfile?.onesignal_player_id as string | null;
+    if (playerId) {
+      try {
+        await sendPushNotification({
+          message: `You received a new ${rating}-star review on: "${jobTitle}".`,
+          playerId,
+        });
+      } catch (e) {
+        console.error("Failed to send push notification", e);
+      }
+    }
 
     setRating(0);
     setComment("");

--- a/src/lib/notification.ts
+++ b/src/lib/notification.ts
@@ -15,3 +15,18 @@ export async function sendPushNotification(payload: PushNotificationPayload) {
   if (error) throw new Error(error.message);
   return data;
 }
+
+export async function savePlayerId(playerId: string) {
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return;
+
+  const tables = ["profile_centra_resident", "profile_centra_tradie"];
+  for (const table of tables) {
+    await supabase
+      .from(table)
+      .update({ onesignal_player_id: playerId })
+      .eq("id", user.id);
+  }
+}

--- a/src/pages/dashboard/jobs.tsx
+++ b/src/pages/dashboard/jobs.tsx
@@ -11,6 +11,7 @@ import { Button } from "@/components/ui/button";
 import { Pencil, Trash2, CheckCircle, Star } from "lucide-react";
 import { useNavigate } from "react-router-dom";
 import DashboardLayout from "@/components/layout/DashboardLayout";
+import { sendPushNotification } from "@/lib/notification";
 
 const DashboardJobs = () => {
   const [jobs, setJobs] = useState<any[]>([]);
@@ -83,6 +84,24 @@ const DashboardJobs = () => {
         related_id: jobId,
         related_type: "job",
       });
+
+      const { data: tradieProfile } = await supabase
+        .from("profile_centra_tradie")
+        .select("onesignal_player_id")
+        .eq("id", tradieId)
+        .single();
+
+      const playerId = tradieProfile?.onesignal_player_id as string | null;
+      if (playerId) {
+        try {
+          await sendPushNotification({
+            message: `You have been assigned to a new job: "${jobTitle}".`,
+            playerId,
+          });
+        } catch (e) {
+          console.error("Failed to send push notification", e);
+        }
+      }
 
       fetchJobs();
     }

--- a/supabase/functions/send_push_notification/index.ts
+++ b/supabase/functions/send_push_notification/index.ts
@@ -23,8 +23,13 @@ serve(async (req) => {
       throw new Error("Missing OneSignal REST API key");
     }
 
+    const appId = Deno.env.get("ONESIGNAL_APP_ID");
+    if (!appId) {
+      throw new Error("Missing OneSignal app ID");
+    }
+
     const payload: Record<string, unknown> = {
-      app_id: "b6d82074-2797-435a-9586-63bc0b55a696",
+      app_id: appId,
       contents: { en: message },
     };
 
@@ -48,6 +53,7 @@ serve(async (req) => {
     const data = await response.json();
 
     if (!response.ok) {
+      console.error("OneSignal error response:", data);
       throw new Error(data.errors?.[0] || "Failed to send notification");
     }
 


### PR DESCRIPTION
## Summary
- store OneSignal app id in environment variables
- read app id from env in `send_push_notification`
- save the OneSignal player id when user subscribes
- send push notifications when jobs are assigned or reviewed

## Testing
- `npm run build`
- `npm run lint` *(fails: 172 errors)*

------
https://chatgpt.com/codex/tasks/task_e_684c0dbbaa80832a86364d45be24ac0f