### PR TITLE
Fix unread counters refresh in dashboard

### DIFF
--- a/src/components/layout/DashboardLayout.tsx
+++ b/src/components/layout/DashboardLayout.tsx
@@ -90,6 +90,16 @@ const DashboardLayout: React.FC<DashboardLayoutProps> = ({
         },
         fetchUnreadCounts
       )
+      .on(
+        "postgres_changes",
+        {
+          event: "UPDATE",
+          schema: "public",
+          table: "messages",
+          filter: `${msgField}=eq.${user.id}`,
+        },
+        fetchUnreadCounts
+      )
       .subscribe();
 
     const notifChannel = supabase
@@ -98,6 +108,16 @@ const DashboardLayout: React.FC<DashboardLayoutProps> = ({
         "postgres_changes",
         {
           event: "INSERT",
+          schema: "public",
+          table: "notifications",
+          filter: `recipient_id=eq.${user.id}`,
+        },
+        fetchUnreadCounts
+      )
+      .on(
+        "postgres_changes",
+        {
+          event: "UPDATE",
           schema: "public",
           table: "notifications",
           filter: `recipient_id=eq.${user.id}`,


### PR DESCRIPTION
## Summary
- extend Supabase realtime channels to listen for updates

## Testing
- `npm install`
- `npm run lint` *(fails: 168 errors)*

------
https://chatgpt.com/codex/tasks/task_e_684c16e55290832aab9b9a6fcd850372