### PR TITLE
Update emergency pricing and credit bundles

### DIFF
--- a/src/components/dashboard/JobPreviewModal.tsx
+++ b/src/components/dashboard/JobPreviewModal.tsx
@@ -75,7 +75,7 @@ const JobPreviewModal: React.FC<JobPreviewModalProps> = ({
           <div className="bg-blue-50 border border-blue-200 rounded-md p-3">
             <p className="text-sm text-blue-800">
               <span className="font-medium">Lead cost: </span>
-              {job.emergency ? 10 : 5} credits
+              {job.emergency ? 2 : 1} credits
             </p>
           </div>
         </div>

--- a/src/components/dashboard/PurchaseLeadModal.tsx
+++ b/src/components/dashboard/PurchaseLeadModal.tsx
@@ -29,7 +29,7 @@ const PurchaseLeadModal: React.FC<PurchaseLeadModalProps> = ({
 }) => {
   if (!job) return null;
 
-  const leadCost = job.emergency ? 10 : 5;
+  const leadCost = job.emergency ? 2 : 1;
   const canPurchase = availableCredits >= leadCost;
 
   return (

--- a/src/components/jobs/JobBoard.tsx
+++ b/src/components/jobs/JobBoard.tsx
@@ -347,7 +347,7 @@ const JobBoard: React.FC<JobBoardProps> = ({
             className="w-full"
             variant={job.type === "emergency" ? "destructive" : "default"}
           >
-            Purchase Lead ({job.type === "emergency" ? "10" : "5"} Credits)
+            Purchase Lead ({job.type === "emergency" ? "2" : "1"} Credits)
           </Button>
         ) : (
           <Button
@@ -441,24 +441,21 @@ const JobBoard: React.FC<JobBoardProps> = ({
                   <CardTitle className="text-lg">Starter</CardTitle>
                 </CardHeader>
                 <CardContent>
-                  <p className="text-2xl font-bold">$50</p>
-                  <p className="text-sm text-gray-500">25 Credits</p>
+                  <p className="text-2xl font-bold text-red-600">$25</p>
+                  <p className="text-sm text-gray-500">5 Credits</p>
                 </CardContent>
                 <CardFooter>
-                  <Button variant="outline" className="w-full">
-                    Purchase
-                  </Button>
+                  <Button variant="outline" className="w-full">Purchase</Button>
                 </CardFooter>
               </Card>
 
-              <Card className="border-primary">
+              <Card>
                 <CardHeader className="pb-2">
-                  <CardTitle className="text-lg">Popular</CardTitle>
-                  <Badge>Best Value</Badge>
+                  <CardTitle className="text-lg">Standard</CardTitle>
                 </CardHeader>
                 <CardContent>
-                  <p className="text-2xl font-bold">$90</p>
-                  <p className="text-sm text-gray-500">50 Credits</p>
+                  <p className="text-2xl font-bold text-red-600">$45</p>
+                  <p className="text-sm text-gray-500">10 Credits</p>
                 </CardContent>
                 <CardFooter>
                   <Button className="w-full">Purchase</Button>
@@ -467,16 +464,27 @@ const JobBoard: React.FC<JobBoardProps> = ({
 
               <Card>
                 <CardHeader className="pb-2">
-                  <CardTitle className="text-lg">Professional</CardTitle>
+                  <CardTitle className="text-lg">Pro</CardTitle>
                 </CardHeader>
                 <CardContent>
-                  <p className="text-2xl font-bold">$180</p>
-                  <p className="text-sm text-gray-500">100 Credits</p>
+                  <p className="text-2xl font-bold text-red-600">$80</p>
+                  <p className="text-sm text-gray-500">20 Credits</p>
                 </CardContent>
                 <CardFooter>
-                  <Button variant="outline" className="w-full">
-                    Purchase
-                  </Button>
+                  <Button variant="outline" className="w-full">Purchase</Button>
+                </CardFooter>
+              </Card>
+
+              <Card>
+                <CardHeader className="pb-2">
+                  <CardTitle className="text-lg">Elite</CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <p className="text-2xl font-bold text-red-600">$180</p>
+                  <p className="text-sm text-gray-500">50 Credits</p>
+                </CardContent>
+                <CardFooter>
+                  <Button variant="outline" className="w-full">Purchase</Button>
                 </CardFooter>
               </Card>
             </div>
@@ -717,7 +725,7 @@ const JobBoard: React.FC<JobBoardProps> = ({
                     <div className="flex justify-between items-center">
                       <span>Cost:</span>
                       <span className="font-medium">
-                        {selectedJob.type === "emergency" ? "10" : "5"} Credits
+                        {selectedJob.type === "emergency" ? "2" : "1"} Credits
                       </span>
                     </div>
                     <div className="flex justify-between items-center mt-2">
@@ -727,7 +735,7 @@ const JobBoard: React.FC<JobBoardProps> = ({
                     <div className="flex justify-between items-center mt-2">
                       <span>Remaining balance:</span>
                       <span className="font-medium">
-                        {credits - (selectedJob.type === "emergency" ? 10 : 5)}{" "}
+                        {credits - (selectedJob.type === "emergency" ? 2 : 1)}{" "}
                         Credits
                       </span>
                     </div>

--- a/src/components/wallet/CreditWallet.tsx
+++ b/src/components/wallet/CreditWallet.tsx
@@ -43,28 +43,10 @@ interface CreditWalletProps {
 }
 
 const creditBundles: CreditBundle[] = [
-  {
-    id: "small",
-    name: "Small",
-    price: 50,
-    credits: 50,
-    bonusCredits: 0,
-  },
-  {
-    id: "medium",
-    name: "Medium",
-    price: 100,
-    credits: 100,
-    bonusCredits: 10,
-    popular: true,
-  },
-  {
-    id: "large",
-    name: "Large",
-    price: 200,
-    credits: 200,
-    bonusCredits: 30,
-  },
+  { id: "starter", name: "Starter", price: 25, credits: 5, bonusCredits: 0 },
+  { id: "standard", name: "Standard", price: 45, credits: 10, bonusCredits: 0 },
+  { id: "pro", name: "Pro", price: 80, credits: 20, bonusCredits: 0 },
+  { id: "elite", name: "Elite", price: 180, credits: 50, bonusCredits: 0 },
 ];
 
 const defaultTransactions: Transaction[] = [
@@ -174,7 +156,7 @@ const CreditWallet: React.FC<CreditWalletProps> = ({
                             </p>
                           </div>
                           <div className="text-right">
-                            <p className="font-bold">${bundle.price}</p>
+                            <p className="font-bold text-red-600">${bundle.price}</p>
                             <p className="text-xs text-gray-500">
                               $
                               {(
@@ -199,7 +181,9 @@ const CreditWallet: React.FC<CreditWalletProps> = ({
                         disabled={!selectedBundle}
                       >
                         <CreditCard className="mr-2 h-4 w-4" />
-                        Pay ${selectedBundle?.price || 0}
+                        <span className="text-red-600">
+                          Pay ${selectedBundle?.price || 0}
+                        </span>
                       </Button>
                     </DialogFooter>
                   </>
@@ -265,7 +249,7 @@ const CreditWallet: React.FC<CreditWalletProps> = ({
                     </div>
                   </CardHeader>
                   <CardContent>
-                    <p className="text-2xl font-bold">${bundle.price}</p>
+                    <p className="text-2xl font-bold text-red-600">${bundle.price}</p>
                     <p className="text-sm text-gray-500">
                       {bundle.credits} Credits
                       {bundle.bonusCredits > 0 && (
@@ -331,7 +315,7 @@ const CreditWallet: React.FC<CreditWalletProps> = ({
                           <Button variant="outline">Cancel</Button>
                           <Button>
                             <CreditCard className="mr-2 h-4 w-4" />
-                            Pay ${bundle.price}
+                            <span className="text-red-600">Pay ${bundle.price}</span>
                           </Button>
                         </DialogFooter>
                       </DialogContent>

--- a/src/pages/dashboard/help.tsx
+++ b/src/pages/dashboard/help.tsx
@@ -51,7 +51,7 @@ const HelpPage = () => {
     {
       question: "How much does it cost to post a job?",
       answer:
-        "Standard job postings are free for homeowners. Emergency job postings have a $25 fee to ensure they get priority attention from tradies. Tradies pay credits to access job details and contact homeowners.",
+        "Standard job postings are free for homeowners. Emergency job postings have a $10 fee to ensure they get priority attention from tradies. Tradies pay credits to access job details and contact homeowners.",
     },
     {
       question: "How do I choose the right tradie for my job?",

--- a/src/pages/dashboard/tradie/help.tsx
+++ b/src/pages/dashboard/tradie/help.tsx
@@ -46,7 +46,7 @@ const TradieHelpPage = () => {
     {
       question: "How do I purchase job leads?",
       answer:
-        "To purchase job leads, browse the available leads in your dashboard and click on the 'Purchase Lead' button. You'll need to have sufficient credits in your wallet. Standard jobs cost 5 credits, while emergency jobs cost 10 credits.",
+        "To purchase job leads, browse the available leads in your dashboard and click on the 'Purchase Lead' button. You'll need to have sufficient credits in your wallet. Standard jobs cost 1 credit, while emergency jobs cost 2 credits.",
     },
     {
       question: "How do I buy credits?",

--- a/src/pages/dashboard/tradie/job-preview.tsx
+++ b/src/pages/dashboard/tradie/job-preview.tsx
@@ -54,7 +54,7 @@ const JobPreviewPage = () => {
   const handlePurchaseLead = async () => {
     if (!job || !profile) return;
 
-    const leadCost = job.is_emergency ? 10 : 5;
+    const leadCost = job.is_emergency ? 2 : 1;
     const updatedCredits = profile.credits - leadCost;
 
     if (updatedCredits < 0) {
@@ -195,7 +195,7 @@ const JobPreviewPage = () => {
 
           <div className="pt-4">
             <Button variant="default" onClick={handlePurchaseLead}>
-              Purchase Lead ({job.is_emergency ? 10 : 5} credits)
+              Purchase Lead ({job.is_emergency ? 2 : 1} credits)
             </Button>
           </div>
         </div>

--- a/src/pages/dashboard/wallet.tsx
+++ b/src/pages/dashboard/wallet.tsx
@@ -32,9 +32,10 @@ const mockTransactions = [
 ];
 
 const creditBundles = [
-  { id: "b1", name: "Starter", credits: 50, price: 50 },
-  { id: "b2", name: "Popular", credits: 110, price: 100, popular: true, savings: "Save 10%" },
-  { id: "b3", name: "Professional", credits: 240, price: 200, savings: "Save 16%" },
+  { id: "b1", name: "Starter", credits: 5, price: 25 },
+  { id: "b2", name: "Standard", credits: 10, price: 45 },
+  { id: "b3", name: "Pro", credits: 20, price: 80 },
+  { id: "b4", name: "Elite", credits: 50, price: 180 },
 ];
 
 const WalletPage = () => {

--- a/src/pages/pricing.tsx
+++ b/src/pages/pricing.tsx
@@ -59,7 +59,7 @@ const Pricing = () => {
                   For urgent needs with faster response times
                 </p>
                 <div className="flex items-baseline gap-2 mb-4">
-                  <span className="text-2xl font-bold">$25</span>
+                  <span className="text-2xl font-bold">$10</span>
                   <span className="text-muted-foreground">
                     per emergency posting
                   </span>
@@ -95,14 +95,14 @@ const Pricing = () => {
                   <Check className="h-5 w-5 text-primary shrink-0 mt-0.5" />
                   <div>
                     <span className="font-medium">Standard Jobs:</span>
-                    <span className="ml-1">5 credits per lead</span>
+                    <span className="ml-1">1 credit per lead</span>
                   </div>
                 </div>
                 <div className="flex items-start gap-3">
                   <Check className="h-5 w-5 text-primary shrink-0 mt-0.5" />
                   <div>
                     <span className="font-medium">Emergency Jobs:</span>
-                    <span className="ml-1">10 credits per lead</span>
+                    <span className="ml-1">2 credits per lead</span>
                   </div>
                 </div>
                 <div className="flex items-start gap-3">
@@ -124,31 +124,23 @@ const Pricing = () => {
                 <div className="grid grid-cols-2 gap-3">
                   <div className="border rounded-lg p-3 text-center">
                     <div className="font-medium">Starter</div>
-                    <div className="text-lg font-bold">$50</div>
-                    <div className="text-sm text-muted-foreground">
-                      50 credits
-                    </div>
+                    <div className="text-lg font-bold text-red-600">$25</div>
+                    <div className="text-sm text-muted-foreground">5 credits</div>
                   </div>
                   <div className="border rounded-lg p-3 text-center">
-                    <div className="font-medium">Popular</div>
-                    <div className="text-lg font-bold">$100</div>
-                    <div className="text-sm text-muted-foreground">
-                      110 credits
-                    </div>
+                    <div className="font-medium">Standard</div>
+                    <div className="text-lg font-bold text-red-600">$45</div>
+                    <div className="text-sm text-muted-foreground">10 credits</div>
                   </div>
                   <div className="border rounded-lg p-3 text-center">
                     <div className="font-medium">Pro</div>
-                    <div className="text-lg font-bold">$200</div>
-                    <div className="text-sm text-muted-foreground">
-                      240 credits
-                    </div>
+                    <div className="text-lg font-bold text-red-600">$80</div>
+                    <div className="text-sm text-muted-foreground">20 credits</div>
                   </div>
                   <div className="border rounded-lg p-3 text-center">
-                    <div className="font-medium">Business</div>
-                    <div className="text-lg font-bold">$500</div>
-                    <div className="text-sm text-muted-foreground">
-                      650 credits
-                    </div>
+                    <div className="font-medium">Elite</div>
+                    <div className="text-lg font-bold text-red-600">$180</div>
+                    <div className="text-sm text-muted-foreground">50 credits</div>
                   </div>
                 </div>
                 <Button asChild className="w-full">


### PR DESCRIPTION
## Summary
- update homeowner emergency posting price to $10
- make tradie lead costs 1 credit for standard jobs and 2 credits for emergency jobs
- revise credit bundles and highlight prices in red
- adjust wallet and job board UIs for new bundles and costs
- update help pages to reflect new pricing

## Testing
- `npm run build-no-errors`
- `npm run lint` *(fails: many existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_684e812b2bac832a9cd5f301694fb6c1