### PR TITLE
Add tradie wallet page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -39,6 +39,7 @@ const TradieHelp = lazy(() => import("./pages/dashboard/tradie/help"));
 const TradieTopTradies = lazy(() => import("./pages/dashboard/tradie/top-tradies"));
 const TradieMyJobs = lazy(() => import("./pages/dashboard/tradie/my-jobs"));
 const TradieFindJobs = lazy(() => import("./pages/dashboard/tradie/find-jobs"));
+const TradieWallet = lazy(() => import("./pages/dashboard/tradie/wallet"));
 
 // Public profile page
 const PublicTradieProfile = lazy(() => import("./pages/public/profile/[tradie_id]"));
@@ -88,6 +89,7 @@ function App() {
           <Route path="/dashboard/tradie/top-tradies" element={<TradieTopTradies />} />
           <Route path="/dashboard/tradie/my-jobs" element={<TradieMyJobs />} />
           <Route path="/dashboard/tradie/find-jobs" element={<TradieFindJobs />} />
+          <Route path="/dashboard/tradie/wallet" element={<TradieWallet />} />
 
           {/* Public tradie profile view */}
           <Route path="/public/profile/:tradie_id" element={<PublicTradieProfile />} />

--- a/src/components/dashboard/TradieDashboard.tsx
+++ b/src/components/dashboard/TradieDashboard.tsx
@@ -93,8 +93,10 @@ const TradieDashboard = ({ profile }: { profile: TradieProfile }) => {
                 </div>
               )}
               <div className="text-xs mt-1">
-                <Gift className="inline h-4 w-4 mr-1" />
-                {profile.credits || 0} credits
+                <Link to="/dashboard/tradie/wallet" className="hover:underline flex items-center">
+                  <Gift className="inline h-4 w-4 mr-1" />
+                  {profile.credits || 0} credits
+                </Link>
               </div>
               <div className="text-xs text-yellow-500 flex items-center mt-1">
                 <Star className="h-4 w-4 mr-1" />

--- a/src/components/layout/DashboardLayout.tsx
+++ b/src/components/layout/DashboardLayout.tsx
@@ -14,6 +14,7 @@ import {
   Search,
   LogOut,
   Menu,
+  Wallet,
 } from "lucide-react";
 import { supabase } from "@/lib/supabaseClient";
 import {
@@ -174,6 +175,7 @@ const DashboardLayout: React.FC<DashboardLayoutProps> = ({
           },
           { name: "Top Tradies", path: "/dashboard/tradie/top-tradies", icon: Award },
           { name: "Profile", path: "/dashboard/tradie/profile", icon: User },
+          { name: "Wallet", path: "/dashboard/tradie/wallet", icon: Wallet },
           { name: "Settings", path: "/dashboard/tradie/settings", icon: Settings },
           { name: "Help", path: "/dashboard/tradie/help", icon: HelpCircle },
         ];

--- a/src/pages/dashboard/tradie/wallet.tsx
+++ b/src/pages/dashboard/tradie/wallet.tsx
@@ -1,0 +1,1 @@
+export { default } from "../wallet";


### PR DESCRIPTION
## Summary
- create tradie wallet route using existing page
- show Wallet nav item in DashboardLayout
- link credits on tradie dashboard to wallet page
- expose route in `App.tsx`

## Testing
- `npm run lint` *(fails: config object using `parser` key not supported)*

------
https://chatgpt.com/codex/tasks/task_e_684e847f1318832a903e62b7cca45465