### PR TITLE
Add password reset flow

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,8 @@ const About = lazy(() => import("./pages/about"));
 const Contact = lazy(() => import("./pages/contact"));
 const Login = lazy(() => import("./pages/login"));
 const Register = lazy(() => import("./pages/register"));
+const ForgotPassword = lazy(() => import("./pages/forgot-password"));
+const ResetPassword = lazy(() => import("./pages/reset-password"));
 
 // Homeowner dashboard pages
 const DashboardPostJob = lazy(() => import("./pages/dashboard/post-job"));
@@ -59,6 +61,8 @@ function App() {
           <Route path="/contact" element={<Contact />} />
           <Route path="/login" element={<Login />} />
           <Route path="/register" element={<Register />} />
+          <Route path="/forgot-password" element={<ForgotPassword />} />
+          <Route path="/reset-password" element={<ResetPassword />} />
 
           {/* Dashboard landing pages */}
           <Route path="/dashboard" element={<Dashboard />} />

--- a/src/pages/forgot-password.tsx
+++ b/src/pages/forgot-password.tsx
@@ -1,0 +1,56 @@
+import React, { useState } from "react";
+import PublicLayout from "@/components/layout/PublicLayout";
+import { supabase } from "@/lib/supabaseClient";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Button } from "@/components/ui/button";
+
+const ForgotPasswordPage = () => {
+  const [email, setEmail] = useState("");
+  const [message, setMessage] = useState("");
+  const [error, setError] = useState("");
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setMessage("");
+    setError("");
+
+    const { error } = await supabase.auth.resetPasswordForEmail(email, {
+      redirectTo: `${window.location.origin}/reset-password`,
+    });
+
+    if (error) {
+      setError(error.message);
+    } else {
+      console.log("Password reset email sent to", email);
+      setMessage("Check your email for the reset link.");
+    }
+  };
+
+  return (
+    <PublicLayout>
+      <div className="max-w-md mx-auto p-6">
+        <h1 className="text-2xl font-bold mb-4">Forgot Password</h1>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <Label htmlFor="email">Email</Label>
+            <Input
+              id="email"
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+            />
+          </div>
+          {error && <p className="text-red-600 text-sm">❌ {error}</p>}
+          {message && <p className="text-green-600 text-sm">{message}</p>}
+          <Button type="submit" className="w-full">
+            Send Reset Link
+          </Button>
+        </form>
+      </div>
+    </PublicLayout>
+  );
+};
+
+export default ForgotPasswordPage;

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -75,6 +75,11 @@ const LoginPage = () => {
               <Input type="email" value={email} onChange={(e) => setEmail(e.target.value)} required />
               <Label>Password</Label>
               <Input type="password" value={password} onChange={(e) => setPassword(e.target.value)} required />
+              <div className="flex justify-end">
+                <a href="/forgot-password" className="text-sm text-primary hover:underline">
+                  Forget your password?
+                </a>
+              </div>
               {error && <p className="text-red-600 text-sm">❌ {error}</p>}
               <Button type="submit" className="w-full">Log In</Button>
             </form>
@@ -86,6 +91,11 @@ const LoginPage = () => {
               <Input type="email" value={email} onChange={(e) => setEmail(e.target.value)} required />
               <Label>Password</Label>
               <Input type="password" value={password} onChange={(e) => setPassword(e.target.value)} required />
+              <div className="flex justify-end">
+                <a href="/forgot-password" className="text-sm text-primary hover:underline">
+                  Forget your password?
+                </a>
+              </div>
               {error && <p className="text-red-600 text-sm">❌ {error}</p>}
               <Button type="submit" className="w-full">Log In</Button>
             </form>

--- a/src/pages/reset-password.tsx
+++ b/src/pages/reset-password.tsx
@@ -1,0 +1,55 @@
+import React, { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import PublicLayout from "@/components/layout/PublicLayout";
+import { supabase } from "@/lib/supabaseClient";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Button } from "@/components/ui/button";
+
+const ResetPasswordPage = () => {
+  const navigate = useNavigate();
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState("");
+  const [success, setSuccess] = useState("");
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError("");
+    setSuccess("");
+    const { error } = await supabase.auth.updateUser({ password });
+    if (error) {
+      setError(error.message);
+    } else {
+      console.log("Password updated");
+      setSuccess("Password updated successfully. Redirecting to log in...");
+      navigate("/login");
+    }
+  };
+
+  return (
+    <PublicLayout>
+      <div className="max-w-md mx-auto p-6">
+        <h1 className="text-2xl font-bold mb-4">Reset Password</h1>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <Label htmlFor="password">New Password</Label>
+            <Input
+              id="password"
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              required
+            />
+          </div>
+          {error && <p className="text-red-600 text-sm">❌ {error}</p>}
+          {success && <p className="text-green-600 text-sm">{success}</p>}
+          <Button type="submit" className="w-full">
+            Update Password
+          </Button>
+        </form>
+      </div>
+    </PublicLayout>
+  );
+};
+
+export default ResetPasswordPage;


### PR DESCRIPTION
## Summary
- add pages for forgot and reset password functionality
- link to forgot password from login page
- register routes for the new pages
- redirect users to login after resetting their password

## Testing
- `npm run lint` *(fails: config uses deprecated parser key)*

------
https://chatgpt.com/codex/tasks/task_e_684e9beb31c0832a80a3918627975e66