### PR TITLE
Fix OneSignal and avatar substring errors

### DIFF
--- a/src/components/OneSignalInit.tsx
+++ b/src/components/OneSignalInit.tsx
@@ -11,12 +11,13 @@ declare global {
 const OneSignalInit = () => {
   const appId = import.meta.env.VITE_ONESIGNAL_APP_ID;
   if (!appId) {
-    console.warn("VITE_ONESIGNAL_APP_ID is not set");
+    console.warn("VITE_ONESIGNAL_APP_ID is not set; OneSignal will not be initialised");
   }
 
   useEffect(() => {
     const loadOneSignal = () => {
       if (window.OneSignal) return;
+      if (!appId) return; // do not attempt to load when appId is missing
 
       const script = document.createElement("script");
       script.src = "https://cdn.onesignal.com/sdks/OneSignalSDK.js";
@@ -61,7 +62,9 @@ const OneSignalInit = () => {
       document.head.appendChild(script);
     };
 
-    loadOneSignal();
+    if (appId) {
+      loadOneSignal();
+    }
   }, []);
 
   return null;

--- a/src/components/settings/ProfilePictureUploader.tsx
+++ b/src/components/settings/ProfilePictureUploader.tsx
@@ -84,8 +84,8 @@ const ProfilePictureUploader: React.FC<ProfilePictureUploaderProps> = ({
     <div className="flex flex-col items-center space-y-4">
       <div className="relative">
         <Avatar className="h-24 w-24">
-          <AvatarImage src={currentAvatar} alt={userName} />
-          <AvatarFallback>{userName.substring(0, 2)}</AvatarFallback>
+          <AvatarImage src={currentAvatar} alt={userName ?? ''} />
+          <AvatarFallback>{userName ? userName.substring(0, 2) : ''}</AvatarFallback>
         </Avatar>
         <Button
           size="icon"


### PR DESCRIPTION
## Summary
- guard against missing OneSignal application ID so script won't load if it isn't configured
- avoid null substring in `ProfilePictureUploader`

## Testing
- `npm run lint` *(fails: A config object is using the "parser" key)*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ec9c904ac832a979b20513ffa5f18