### PR TITLE
Add OneSignal prompt effect

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ export default {
 - Optionally add `plugin:@typescript-eslint/stylistic-type-checked`
 - Install [eslint-plugin-react](https://github.com/jsx-eslint/eslint-plugin-react) and add `plugin:react/recommended` & `plugin:react/jsx-runtime` to the `extends` list
 
+## OneSignal Setup
+
+To enable push notification prompts the environment variable `VITE_ONESIGNAL_APP_ID` must be defined. Refer to `.env.example` for configuration details.
+
 ## License
 
 This project is licensed under the [MIT License](LICENSE).

--- a/src/components/OneSignalInit.tsx
+++ b/src/components/OneSignalInit.tsx
@@ -51,10 +51,6 @@ const OneSignalInit = () => {
             }
           });
 
-          // Optionally prompt the user manually (or remove this block if you only want auto-prompt)
-          window.OneSignal.showSlidedownPrompt().catch((e: any) => {
-            console.warn("Prompt error:", e);
-          });
         });
       };
 
@@ -62,6 +58,31 @@ const OneSignalInit = () => {
     };
 
     loadOneSignal();
+  }, []);
+
+  useEffect(() => {
+    const promptIfNeeded = async () => {
+      try {
+        const enabled = await window.OneSignal.isPushNotificationsEnabled();
+        if (!enabled) {
+          await window.OneSignal.showSlidedownPrompt();
+        }
+      } catch (e) {
+        console.warn("Prompt error:", e);
+      }
+    };
+
+    if (window.OneSignal && typeof window.OneSignal.push === 'function') {
+      window.OneSignal.push(promptIfNeeded);
+    } else {
+      const interval = setInterval(() => {
+        if (window.OneSignal && typeof window.OneSignal.push === 'function') {
+          clearInterval(interval);
+          window.OneSignal.push(promptIfNeeded);
+        }
+      }, 100);
+      return () => clearInterval(interval);
+    }
   }, []);
 
   return null;


### PR DESCRIPTION
## Summary
- load the OneSignal prompt once the SDK is ready
- only prompt if push notifications aren't enabled
- document that `VITE_ONESIGNAL_APP_ID` must be set

## Testing
- `npm install`
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_684ec9dbd8c4832a81df065bf5eb7c02