### PR TITLE
Add conditional post-job link in footer

### DIFF
--- a/src/components/layout/PublicLayout.tsx
+++ b/src/components/layout/PublicLayout.tsx
@@ -65,6 +65,14 @@ const PublicLayout: React.FC<PublicLayoutProps> = ({ children }) => {
     }
   };
 
+  const handlePostJobClick = () => {
+    if (loggedIn && role === "homeowner") {
+      navigate("/post-job");
+    } else {
+      navigate("/login?redirect=/post-job");
+    }
+  };
+
   const isActive = (path: string) => location.pathname === path;
 
   const navItems = [
@@ -273,9 +281,12 @@ const PublicLayout: React.FC<PublicLayoutProps> = ({ children }) => {
               <h3 className="text-lg font-semibold mb-4">For Homeowners</h3>
               <ul className="space-y-2 text-sm">
                 <li>
-                  <Link to="/post-job" className="text-gray-600 hover:text-primary">
+                  <button
+                    onClick={handlePostJobClick}
+                    className="text-gray-600 hover:text-primary"
+                  >
                     Post a Job
-                  </Link>
+                  </button>
                 </li>
                 <li>
                   <Link to="/how-it-works" className="text-gray-600 hover:text-primary">


### PR DESCRIPTION
## Summary
- add helper in `PublicLayout` to redirect to login unless logged in as a homeowner
- update footer button to use this helper when posting a job

## Testing
- `npm run lint` *(fails: parser not supported in config)*
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ec995c8e0832abae111c0cb8745b1