### PR TITLE
Add Stripe credit card payment page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -43,6 +43,7 @@ const TradieWallet = lazy(() => import("./pages/dashboard/tradie/wallet"));
 
 // Public profile page
 const PublicTradieProfile = lazy(() => import("./pages/public/profile/[tradie_id]"));
+const CreditCardPayment = lazy(() => import("./pages/credit-card-payment"));
 
 function App() {
   return (
@@ -60,7 +61,8 @@ function App() {
           <Route path="/login" element={<Login />} />
           <Route path="/register" element={<Register />} />
           <Route path="/forgot-password" element={<ForgotPassword />} />
-          <Route path="/reset-password" element={<ResetPassword />} />
+         <Route path="/reset-password" element={<ResetPassword />} />
+          <Route path="/pay/credit-card" element={<CreditCardPayment />} />
 
           {/* Dashboard landing pages */}
           <Route path="/dashboard" element={<Dashboard />} />

--- a/src/components/jobs/PostJobForm.tsx
+++ b/src/components/jobs/PostJobForm.tsx
@@ -136,6 +136,12 @@ const PostJobForm: React.FC<{ onSuccess?: () => void }> = ({ onSuccess }) => {
       onSuccess();
     } else {
       setSuccess("✅ Job posted successfully!");
+
+      if (isEmergency && formData.paymentMethod === "credit-card") {
+        navigate("/pay/credit-card");
+        return;
+      }
+
       setFormData({
         title: "",
         description: "",

--- a/src/pages/credit-card-payment.tsx
+++ b/src/pages/credit-card-payment.tsx
@@ -1,0 +1,25 @@
+import React, { useEffect } from "react";
+
+const CreditCardPayment: React.FC = () => {
+  useEffect(() => {
+    const script = document.createElement("script");
+    script.src = "https://js.stripe.com/v3/buy-button.js";
+    script.async = true;
+    document.body.appendChild(script);
+
+    return () => {
+      document.body.removeChild(script);
+    };
+  }, []);
+
+  return (
+    <div className="flex justify-center items-center min-h-screen">
+      <stripe-buy-button
+        buy-button-id="buy_btn_1RaHNoQ9V4aAIaGVx1LiZX1z"
+        publishable-key="pk_test_51RRT3EQ9V4aAIaGV7OjdmRNhg1lTln0Sx90T0r5dt98r9AhYH5onQ4Gu9dGpc67VZ2NlxRkdUq6Aeb0C9fKMPK8P00h8s2uaLB"
+      ></stripe-buy-button>
+    </div>
+  );
+};
+
+export default CreditCardPayment;


### PR DESCRIPTION
## Summary
- add new page with Stripe buy button
- redirect emergency credit-card jobs to payment page
- route `/pay/credit-card` to the new page

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any, ban-ts-comment)*

------
https://chatgpt.com/codex/tasks/task_e_684ed605c818832ab33e2b113ebfc5d0