### PR TITLE
Integrate Stripe starter bundle purchase

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -44,6 +44,8 @@ const TradieWallet = lazy(() => import("./pages/dashboard/tradie/wallet"));
 // Public profile page
 const PublicTradieProfile = lazy(() => import("./pages/public/profile/[tradie_id]"));
 const CreditCardPayment = lazy(() => import("./pages/credit-card-payment"));
+const StarterPayment = lazy(() => import("./pages/starter-payment"));
+const StarterSuccess = lazy(() => import("./pages/starter-success"));
 
 function App() {
   return (
@@ -62,7 +64,9 @@ function App() {
           <Route path="/register" element={<Register />} />
           <Route path="/forgot-password" element={<ForgotPassword />} />
          <Route path="/reset-password" element={<ResetPassword />} />
-          <Route path="/pay/credit-card" element={<CreditCardPayment />} />
+         <Route path="/pay/credit-card" element={<CreditCardPayment />} />
+         <Route path="/pay/starter" element={<StarterPayment />} />
+         <Route path="/pay/starter-success" element={<StarterSuccess />} />
 
           {/* Dashboard landing pages */}
           <Route path="/dashboard" element={<Dashboard />} />

--- a/src/pages/dashboard/wallet.tsx
+++ b/src/pages/dashboard/wallet.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from "react";
+import { useNavigate } from "react-router-dom";
 import DashboardLayout from "@/components/layout/DashboardLayout";
 import {
   Card,
@@ -39,6 +40,7 @@ const creditBundles = [
 ];
 
 const WalletPage = () => {
+  const navigate = useNavigate();
   const [activeTab, setActiveTab] = useState("credits");
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [profile, setProfile] = useState<any>(null);
@@ -166,7 +168,14 @@ const WalletPage = () => {
                       )}
                     </CardContent>
                     <CardFooter>
-                      <Button className="w-full" onClick={() => setIsModalOpen(true)}>
+                      <Button
+                        className="w-full"
+                        onClick={() =>
+                          bundle.id === "b1"
+                            ? navigate("/pay/starter")
+                            : setIsModalOpen(true)
+                        }
+                      >
                         Purchase
                       </Button>
                     </CardFooter>

--- a/src/pages/starter-payment.tsx
+++ b/src/pages/starter-payment.tsx
@@ -1,0 +1,24 @@
+import React, { useEffect } from "react";
+
+const StarterPayment: React.FC = () => {
+  useEffect(() => {
+    const script = document.createElement("script");
+    script.src = "https://js.stripe.com/v3/buy-button.js";
+    script.async = true;
+    document.body.appendChild(script);
+    return () => {
+      document.body.removeChild(script);
+    };
+  }, []);
+
+  return (
+    <div className="flex justify-center items-center min-h-screen">
+      <stripe-buy-button
+        buy-button-id="buy_btn_1RaIXSQ9V4aAIaGVOovF8CmN"
+        publishable-key="pk_test_51RRT3EQ9V4aAIaGV7OjdmRNhg1lTln0Sx90T0r5dt98r9AhYH5onQ4Gu9dGpc67VZ2NlxRkdUq6Aeb0C9fKMPK8P00h8s2uaLB"
+      ></stripe-buy-button>
+    </div>
+  );
+};
+
+export default StarterPayment;

--- a/src/pages/starter-success.tsx
+++ b/src/pages/starter-success.tsx
@@ -1,0 +1,38 @@
+import React, { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { supabase } from "@/lib/supabaseClient";
+
+const StarterSuccess: React.FC = () => {
+  const navigate = useNavigate();
+  const [message, setMessage] = useState("Adding credits...");
+
+  useEffect(() => {
+    const addCredits = async () => {
+      const { data: userData } = await supabase.auth.getUser();
+      const userId = userData?.user?.id;
+      if (!userId) {
+        setMessage("Unable to determine user.");
+        return;
+      }
+      const { error } = await supabase.rpc("increment_credits", {
+        user_id: userId,
+        amount: 5,
+      });
+      if (error) {
+        setMessage("Failed to add credits.");
+      } else {
+        setMessage("5 credits added to your account!");
+        setTimeout(() => navigate("/dashboard/tradie/wallet"), 3000);
+      }
+    };
+    addCredits();
+  }, [navigate]);
+
+  return (
+    <div className="flex justify-center items-center min-h-screen">
+      <p className="text-lg font-medium">{message}</p>
+    </div>
+  );
+};
+
+export default StarterSuccess;


### PR DESCRIPTION
## Summary
- wire in new starter bundle purchase pages
- update wallet page to use Stripe starter checkout
- add success page to credit the user after purchase

## Testing
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ee80bb138832a890294728ce76b98