### PR TITLE
Add Stripe payment success handler

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -44,6 +44,7 @@ const TradieWallet = lazy(() => import("./pages/dashboard/tradie/wallet"));
 // Public profile page
 const PublicTradieProfile = lazy(() => import("./pages/public/profile/[tradie_id]"));
 const CreditCardPayment = lazy(() => import("./pages/credit-card-payment"));
+const StripeSuccess = lazy(() => import("./pages/stripe-success"));
 
 function App() {
   return (
@@ -63,6 +64,7 @@ function App() {
           <Route path="/forgot-password" element={<ForgotPassword />} />
          <Route path="/reset-password" element={<ResetPassword />} />
           <Route path="/pay/credit-card" element={<CreditCardPayment />} />
+          <Route path="/pay/success" element={<StripeSuccess />} />
 
           {/* Dashboard landing pages */}
           <Route path="/dashboard" element={<Dashboard />} />

--- a/src/pages/credit-card-payment.tsx
+++ b/src/pages/credit-card-payment.tsx
@@ -15,7 +15,7 @@ const CreditCardPayment: React.FC = () => {
   return (
     <div className="flex justify-center items-center min-h-screen">
       <stripe-buy-button
-        buy-button-id="buy_btn_1RaHNoQ9V4aAIaGVx1LiZX1z"
+        buy-button-id="buy_btn_1RaIeZQ9V4aAIaGVH7un20qj"
         publishable-key="pk_test_51RRT3EQ9V4aAIaGV7OjdmRNhg1lTln0Sx90T0r5dt98r9AhYH5onQ4Gu9dGpc67VZ2NlxRkdUq6Aeb0C9fKMPK8P00h8s2uaLB"
       ></stripe-buy-button>
     </div>

--- a/src/pages/stripe-success.tsx
+++ b/src/pages/stripe-success.tsx
@@ -1,0 +1,45 @@
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { supabase } from "@/lib/supabaseClient";
+
+const StripeSuccess = () => {
+  const navigate = useNavigate();
+  const [status, setStatus] = useState<"processing" | "success" | "error">("processing");
+
+  useEffect(() => {
+    const addCredits = async () => {
+      const { data: { user } } = await supabase.auth.getUser();
+      if (!user) {
+        setStatus("error");
+        return;
+      }
+      const { error } = await supabase.rpc("increment_credits", {
+        user_id: user.id,
+        amount: 10,
+      });
+      if (error) {
+        console.error("Failed to add credits:", error);
+        setStatus("error");
+        return;
+      }
+      setStatus("success");
+    };
+    addCredits();
+  }, []);
+
+  return (
+    <div className="flex items-center justify-center min-h-screen flex-col space-y-4">
+      {status === "processing" && <p>Processing your purchase...</p>}
+      {status === "success" && <>
+        <p>Credits added to your account!</p>
+        <button className="px-4 py-2 bg-primary text-white rounded" onClick={() => navigate("/dashboard/tradie/wallet")}>Go to Wallet</button>
+      </>}
+      {status === "error" && <>
+        <p>There was an issue updating your credits.</p>
+        <button className="px-4 py-2 bg-primary text-white rounded" onClick={() => navigate("/dashboard/tradie/wallet")}>Back</button>
+      </>}
+    </div>
+  );
+};
+
+export default StripeSuccess;


### PR DESCRIPTION
## Summary
- update credit card payment button to use standard bundle ID
- handle Stripe success route for credit wallet purchases
- wire up success page in the router

## Testing
- `npm run test`
- `npm run lint` *(fails: A config object is using the "parser" key, which is not supported in flat config system)*

------
https://chatgpt.com/codex/tasks/task_e_684ee98e2244832ab9a92cedb9859577