### PR TITLE
Add standard bundle Stripe payment

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -48,6 +48,8 @@ const StarterPayment = lazy(() => import("./pages/starter-payment"));
 const StarterSuccess = lazy(() => import("./pages/starter-success"));
 const StandardPayment = lazy(() => import("./pages/standard-payment"));
 const StandardSuccess = lazy(() => import("./pages/standard-success"));
+const ProPayment = lazy(() => import("./pages/pro-payment"));
+const ProSuccess = lazy(() => import("./pages/pro-success"));
 
 function App() {
   return (
@@ -71,6 +73,8 @@ function App() {
          <Route path="/pay/starter-success" element={<StarterSuccess />} />
          <Route path="/pay/standard" element={<StandardPayment />} />
          <Route path="/pay/standard-success" element={<StandardSuccess />} />
+         <Route path="/pay/pro" element={<ProPayment />} />
+         <Route path="/pay/pro-success" element={<ProSuccess />} />
 
           {/* Dashboard landing pages */}
           <Route path="/dashboard" element={<Dashboard />} />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -44,6 +44,10 @@ const TradieWallet = lazy(() => import("./pages/dashboard/tradie/wallet"));
 // Public profile page
 const PublicTradieProfile = lazy(() => import("./pages/public/profile/[tradie_id]"));
 const CreditCardPayment = lazy(() => import("./pages/credit-card-payment"));
+const StarterPayment = lazy(() => import("./pages/starter-payment"));
+const StarterSuccess = lazy(() => import("./pages/starter-success"));
+const StandardPayment = lazy(() => import("./pages/standard-payment"));
+const StandardSuccess = lazy(() => import("./pages/standard-success"));
 
 function App() {
   return (
@@ -62,7 +66,11 @@ function App() {
           <Route path="/register" element={<Register />} />
           <Route path="/forgot-password" element={<ForgotPassword />} />
          <Route path="/reset-password" element={<ResetPassword />} />
-          <Route path="/pay/credit-card" element={<CreditCardPayment />} />
+         <Route path="/pay/credit-card" element={<CreditCardPayment />} />
+         <Route path="/pay/starter" element={<StarterPayment />} />
+         <Route path="/pay/starter-success" element={<StarterSuccess />} />
+         <Route path="/pay/standard" element={<StandardPayment />} />
+         <Route path="/pay/standard-success" element={<StandardSuccess />} />
 
           {/* Dashboard landing pages */}
           <Route path="/dashboard" element={<Dashboard />} />

--- a/src/pages/dashboard/wallet.tsx
+++ b/src/pages/dashboard/wallet.tsx
@@ -175,6 +175,8 @@ const WalletPage = () => {
                             ? navigate("/pay/starter")
                             : bundle.id === "b2"
                             ? navigate("/pay/standard")
+                            : bundle.id === "b3"
+                            ? navigate("/pay/pro")
                             : setIsModalOpen(true)
                         }
                       >

--- a/src/pages/dashboard/wallet.tsx
+++ b/src/pages/dashboard/wallet.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from "react";
+import { useNavigate } from "react-router-dom";
 import DashboardLayout from "@/components/layout/DashboardLayout";
 import {
   Card,
@@ -39,6 +40,7 @@ const creditBundles = [
 ];
 
 const WalletPage = () => {
+  const navigate = useNavigate();
   const [activeTab, setActiveTab] = useState("credits");
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [profile, setProfile] = useState<any>(null);
@@ -166,7 +168,16 @@ const WalletPage = () => {
                       )}
                     </CardContent>
                     <CardFooter>
-                      <Button className="w-full" onClick={() => setIsModalOpen(true)}>
+                      <Button
+                        className="w-full"
+                        onClick={() =>
+                          bundle.id === "b1"
+                            ? navigate("/pay/starter")
+                            : bundle.id === "b2"
+                            ? navigate("/pay/standard")
+                            : setIsModalOpen(true)
+                        }
+                      >
                         Purchase
                       </Button>
                     </CardFooter>

--- a/src/pages/pro-payment.tsx
+++ b/src/pages/pro-payment.tsx
@@ -1,0 +1,24 @@
+import React, { useEffect } from "react";
+
+const ProPayment: React.FC = () => {
+  useEffect(() => {
+    const script = document.createElement("script");
+    script.src = "https://js.stripe.com/v3/buy-button.js";
+    script.async = true;
+    document.body.appendChild(script);
+    return () => {
+      document.body.removeChild(script);
+    };
+  }, []);
+
+  return (
+    <div className="flex justify-center items-center min-h-screen">
+      <stripe-buy-button
+        buy-button-id="buy_btn_1RaIlOQ9V4aAIaGVeHH2uPzE"
+        publishable-key="pk_test_51RRT3EQ9V4aAIaGV7OjdmRNhg1lTln0Sx90T0r5dt98r9AhYH5onQ4Gu9dGpc67VZ2NlxRkdUq6Aeb0C9fKMPK8P00h8s2uaLB"
+      ></stripe-buy-button>
+    </div>
+  );
+};
+
+export default ProPayment;

--- a/src/pages/pro-success.tsx
+++ b/src/pages/pro-success.tsx
@@ -1,0 +1,38 @@
+import React, { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { supabase } from "@/lib/supabaseClient";
+
+const ProSuccess: React.FC = () => {
+  const navigate = useNavigate();
+  const [message, setMessage] = useState("Adding credits...");
+
+  useEffect(() => {
+    const addCredits = async () => {
+      const { data: userData } = await supabase.auth.getUser();
+      const userId = userData?.user?.id;
+      if (!userId) {
+        setMessage("Unable to determine user.");
+        return;
+      }
+      const { error } = await supabase.rpc("increment_credits", {
+        user_id: userId,
+        amount: 20,
+      });
+      if (error) {
+        setMessage("Failed to add credits.");
+      } else {
+        setMessage("20 credits added to your account!");
+        setTimeout(() => navigate("/dashboard/tradie/wallet"), 3000);
+      }
+    };
+    addCredits();
+  }, [navigate]);
+
+  return (
+    <div className="flex justify-center items-center min-h-screen">
+      <p className="text-lg font-medium">{message}</p>
+    </div>
+  );
+};
+
+export default ProSuccess;

--- a/src/pages/standard-payment.tsx
+++ b/src/pages/standard-payment.tsx
@@ -1,0 +1,24 @@
+import React, { useEffect } from "react";
+
+const StandardPayment: React.FC = () => {
+  useEffect(() => {
+    const script = document.createElement("script");
+    script.src = "https://js.stripe.com/v3/buy-button.js";
+    script.async = true;
+    document.body.appendChild(script);
+    return () => {
+      document.body.removeChild(script);
+    };
+  }, []);
+
+  return (
+    <div className="flex justify-center items-center min-h-screen">
+      <stripe-buy-button
+        buy-button-id="buy_btn_1RaIeZQ9V4aAIaGVH7un20qj"
+        publishable-key="pk_test_51RRT3EQ9V4aAIaGV7OjdmRNhg1lTln0Sx90T0r5dt98r9AhYH5onQ4Gu9dGpc67VZ2NlxRkdUq6Aeb0C9fKMPK8P00h8s2uaLB"
+      ></stripe-buy-button>
+    </div>
+  );
+};
+
+export default StandardPayment;

--- a/src/pages/standard-success.tsx
+++ b/src/pages/standard-success.tsx
@@ -1,0 +1,38 @@
+import React, { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { supabase } from "@/lib/supabaseClient";
+
+const StandardSuccess: React.FC = () => {
+  const navigate = useNavigate();
+  const [message, setMessage] = useState("Adding credits...");
+
+  useEffect(() => {
+    const addCredits = async () => {
+      const { data: userData } = await supabase.auth.getUser();
+      const userId = userData?.user?.id;
+      if (!userId) {
+        setMessage("Unable to determine user.");
+        return;
+      }
+      const { error } = await supabase.rpc("increment_credits", {
+        user_id: userId,
+        amount: 10,
+      });
+      if (error) {
+        setMessage("Failed to add credits.");
+      } else {
+        setMessage("10 credits added to your account!");
+        setTimeout(() => navigate("/dashboard/tradie/wallet"), 3000);
+      }
+    };
+    addCredits();
+  }, [navigate]);
+
+  return (
+    <div className="flex justify-center items-center min-h-screen">
+      <p className="text-lg font-medium">{message}</p>
+    </div>
+  );
+};
+
+export default StandardSuccess;

--- a/src/pages/starter-payment.tsx
+++ b/src/pages/starter-payment.tsx
@@ -1,0 +1,24 @@
+import React, { useEffect } from "react";
+
+const StarterPayment: React.FC = () => {
+  useEffect(() => {
+    const script = document.createElement("script");
+    script.src = "https://js.stripe.com/v3/buy-button.js";
+    script.async = true;
+    document.body.appendChild(script);
+    return () => {
+      document.body.removeChild(script);
+    };
+  }, []);
+
+  return (
+    <div className="flex justify-center items-center min-h-screen">
+      <stripe-buy-button
+        buy-button-id="buy_btn_1RaIXSQ9V4aAIaGVOovF8CmN"
+        publishable-key="pk_test_51RRT3EQ9V4aAIaGV7OjdmRNhg1lTln0Sx90T0r5dt98r9AhYH5onQ4Gu9dGpc67VZ2NlxRkdUq6Aeb0C9fKMPK8P00h8s2uaLB"
+      ></stripe-buy-button>
+    </div>
+  );
+};
+
+export default StarterPayment;

--- a/src/pages/starter-success.tsx
+++ b/src/pages/starter-success.tsx
@@ -1,0 +1,38 @@
+import React, { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { supabase } from "@/lib/supabaseClient";
+
+const StarterSuccess: React.FC = () => {
+  const navigate = useNavigate();
+  const [message, setMessage] = useState("Adding credits...");
+
+  useEffect(() => {
+    const addCredits = async () => {
+      const { data: userData } = await supabase.auth.getUser();
+      const userId = userData?.user?.id;
+      if (!userId) {
+        setMessage("Unable to determine user.");
+        return;
+      }
+      const { error } = await supabase.rpc("increment_credits", {
+        user_id: userId,
+        amount: 5,
+      });
+      if (error) {
+        setMessage("Failed to add credits.");
+      } else {
+        setMessage("5 credits added to your account!");
+        setTimeout(() => navigate("/dashboard/tradie/wallet"), 3000);
+      }
+    };
+    addCredits();
+  }, [navigate]);
+
+  return (
+    <div className="flex justify-center items-center min-h-screen">
+      <p className="text-lg font-medium">{message}</p>
+    </div>
+  );
+};
+
+export default StarterSuccess;


### PR DESCRIPTION
## Summary
- add pages for Stripe standard bundle purchase and success
- route standard bundle in wallet to the new Stripe page
- wire new lazy routes for the standard bundle payment flow
- include dev dependencies to enable running tests

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684ee80bb138832a890294728ce76b98